### PR TITLE
Add range finder display

### DIFF
--- a/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/models/CameraStreamDetailVM.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/models/CameraStreamDetailVM.kt
@@ -43,6 +43,7 @@ class CameraStreamDetailVM : DJIViewModel() {
     private val _visionAssistViewDirection = MutableLiveData(VisionAssistDirection.UNKNOWN)
     private val _visionAssistViewDirectionRange = MutableLiveData<List<VisionAssistDirection>>(ArrayList())
     val cameraStreamEnableMap = MutableLiveData(emptyMap<ComponentIndexType, Boolean>())
+    private val _laserMeasureDistance = MutableLiveData<Double>()
 
     private var cameraIndex = ComponentIndexType.UNKNOWN
     private var cameraType = ""
@@ -100,6 +101,7 @@ class CameraStreamDetailVM : DJIViewModel() {
         MediaDataCenter.getInstance().cameraStreamManager.removeVisionAssistStatusListener(visionAssistStatusListener)
         KeyManager.getInstance().cancelListen(this)
         doStopDownloadStreamToLocal()
+        CameraKey.KeyLaserMeasureEnabled.create(cameraIndex).set(false)
     }
 
     fun setCameraIndex(cameraIndex: ComponentIndexType) {
@@ -115,6 +117,7 @@ class CameraStreamDetailVM : DJIViewModel() {
         listenAvailableLens()
         listenCurrentLens()
         listenVisionAssistStatus()
+        listenLaserMeasureInfo()
         MediaDataCenter.getInstance().cameraStreamManager.addAvailableCameraUpdatedListener(availableCameraUpdatedListener)
     }
 
@@ -177,6 +180,18 @@ class CameraStreamDetailVM : DJIViewModel() {
 
     private fun listenVisionAssistStatus() {
         MediaDataCenter.getInstance().cameraStreamManager.addVisionAssistStatusListener(visionAssistStatusListener)
+    }
+
+    private fun listenLaserMeasureInfo() {
+        if (cameraIndex == ComponentIndexType.UNKNOWN) {
+            return
+        }
+        // Enable laser measure module
+        CameraKey.KeyLaserMeasureEnabled.create(cameraIndex).set(true)
+        // Listen distance info
+        CameraKey.KeyLaserMeasureInformation.create(cameraIndex).listen(this) {
+            _laserMeasureDistance.postValue(it?.distance ?: -1.0)
+        }
     }
 
     fun changeCameraLens(lensType: CameraVideoStreamSourceType) {
@@ -311,4 +326,7 @@ class CameraStreamDetailVM : DJIViewModel() {
 
     val visionAssistViewDirectionRange: LiveData<List<VisionAssistDirection>>
         get() = _visionAssistViewDirectionRange
+
+    val laserMeasureDistance: LiveData<Double>
+        get() = _laserMeasureDistance
 }

--- a/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/pages/CameraStreamDetailFragment.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/pages/CameraStreamDetailFragment.kt
@@ -62,6 +62,7 @@ class CameraStreamDetailFragment : DJIFragment() {
     private lateinit var cameraSurfaceView: SurfaceView
     private lateinit var btnDownloadYUV: Button
     private lateinit var tvCameraName: TextView
+    private lateinit var tvLaserDistance: TextView
     private lateinit var btnCloseOrOpen: Button
     private lateinit var btnCloseOrOpenVisionAssist: Button
     private lateinit var btnBeginDownloadStream: Button
@@ -108,6 +109,7 @@ class CameraStreamDetailFragment : DJIFragment() {
         cameraSurfaceView = view.findViewById(R.id.sv_camera)
         btnDownloadYUV = view.findViewById(R.id.btn_download_yuv)
         tvCameraName = view.findViewById(R.id.tv_camera_name)
+        tvLaserDistance = view.findViewById(R.id.tv_laser_distance)
         btnCloseOrOpen = view.findViewById(R.id.btn_close_or_open)
         btnCloseOrOpenVisionAssist = view.findViewById(R.id.btn_vision_assist_close_or_open)
         btnBeginDownloadStream = view.findViewById(R.id.btn_begin_download_stream)
@@ -217,6 +219,16 @@ class CameraStreamDetailFragment : DJIFragment() {
 
         viewModel.cameraName.observe(viewLifecycleOwner) { name ->
             tvCameraName.text = name
+        }
+
+        viewModel.laserMeasureDistance.observe(viewLifecycleOwner) {
+            val distance = it ?: -1.0
+            val text = if (distance >= 0) {
+                String.format("Laser Distance: %.1f m", distance)
+            } else {
+                "Laser Distance: --"
+            }
+            tvLaserDistance.text = text
         }
 
         viewModel.isVisionAssistEnabled.observe(viewLifecycleOwner) {

--- a/SampleCode-V5/android-sdk-v5-sample/src/main/res/layout/fragment_camera_stream_detail.xml
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/res/layout/fragment_camera_stream_detail.xml
@@ -18,6 +18,15 @@
         android:textSize="13sp"
         android:textStyle="bold" />
 
+    <TextView
+        android:id="@+id/tv_laser_distance"
+        android:layout_width="wrap_content"
+        android:layout_height="24dp"
+        android:gravity="center"
+        android:textColor="@color/white"
+        android:textSize="13sp"
+        android:text="Laser Distance: --" />
+
     <SurfaceView
         android:id="@+id/sv_camera"
         android:layout_width="match_parent"

--- a/SampleCode-V5/android-sdk-v5-sample/src/main/res/layout/fragment_camera_stream_detail_single.xml
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/res/layout/fragment_camera_stream_detail_single.xml
@@ -26,6 +26,17 @@
             app:layout_constraintStart_toStartOf="@id/ll_live_info_layout"
             app:layout_constraintStart_toEndOf="@id/ll_live_info_layout"/>
 
+        <TextView
+            android:id="@+id/tv_laser_distance"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:textColor="@color/white"
+            android:text="Laser Distance: --"
+            android:textSize="15sp"
+            app:layout_constraintTop_toBottomOf="@id/tv_camera_name"
+            app:layout_constraintStart_toStartOf="@id/tv_camera_name"/>
+
         <androidx.core.widget.NestedScrollView
             android:id="@+id/ll_live_info_layout"
             android:layout_width="wrap_content"


### PR DESCRIPTION
## Summary
- hook into KeyLaserMeasureInformation and expose distance data
- display laser range finder distance in camera stream detail screens

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685e9564a84083239db74a6b3435d87e