### PR TITLE
Add Laser Range Finder widget

### DIFF
--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidget.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidget.kt
@@ -1,0 +1,100 @@
+package dji.v5.ux.core.widget.laserrange
+
+import android.content.Context
+import android.util.AttributeSet
+import io.reactivex.rxjava3.core.Flowable
+import dji.v5.ux.R
+import dji.v5.ux.core.base.DJISDKModel
+import dji.v5.ux.core.base.SchedulerProvider
+import dji.v5.ux.core.base.WidgetSizeDescription
+import dji.v5.ux.core.base.widget.BaseTelemetryWidget
+import dji.v5.ux.core.communication.ObservableInMemoryKeyedStore
+import dji.v5.ux.core.extension.getDistanceString
+import dji.v5.ux.core.extension.getString
+import dji.v5.ux.core.util.UnitConversionUtil
+import dji.v5.ux.core.widget.laserrange.LaserRangeWidget.ModelState
+import dji.v5.ux.core.widget.laserrange.LaserRangeWidgetModel.RangeState
+import java.text.DecimalFormat
+
+/**
+ * Widget that displays the distance measured by the camera laser range finder.
+ */
+open class LaserRangeWidget @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+    widgetTheme: Int = 0
+) : BaseTelemetryWidget<ModelState>(
+    context,
+    attrs,
+    defStyleAttr,
+    WidgetType.TEXT,
+    widgetTheme,
+    R.style.UXSDKLaserRangeWidget
+) {
+
+    override val metricDecimalFormat: DecimalFormat = DecimalFormat("###0.0")
+    override val imperialDecimalFormat: DecimalFormat = DecimalFormat("###0")
+
+    private val widgetModel: LaserRangeWidgetModel by lazy {
+        LaserRangeWidgetModel(
+            DJISDKModel.getInstance(),
+            ObservableInMemoryKeyedStore.getInstance()
+        )
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        if (!isInEditMode) {
+            widgetModel.setup()
+        }
+    }
+
+    override fun onDetachedFromWindow() {
+        if (!isInEditMode) {
+            widgetModel.cleanup()
+        }
+        super.onDetachedFromWindow()
+    }
+
+    override fun reactToModelChanges() {
+        addReaction(widgetModel.productConnection
+            .observeOn(SchedulerProvider.ui())
+            .subscribe { widgetStateDataProcessor.onNext(ModelState.ProductConnected(it)) })
+        addReaction(widgetModel.rangeState
+            .observeOn(SchedulerProvider.ui())
+            .subscribe { updateUI(it) })
+    }
+
+    private fun updateUI(state: RangeState) {
+        widgetStateDataProcessor.onNext(ModelState.RangeStateUpdated(state))
+        when (state) {
+            RangeState.ProductDisconnected, RangeState.RangeUnavailable -> {
+                valueString = getString(R.string.uxsdk_string_default_value)
+                unitString = null
+            }
+            is RangeState.CurrentRange -> {
+                valueString = getDecimalFormat(UnitConversionUtil.UnitType.METRIC).format(state.distance)
+                unitString = getDistanceString(UnitConversionUtil.UnitType.METRIC)
+            }
+        }
+    }
+
+    override fun getIdealDimensionRatioString(): String? = null
+
+    override val widgetSizeDescription: WidgetSizeDescription =
+        WidgetSizeDescription(WidgetSizeDescription.SizeType.OTHER,
+            widthDimension = WidgetSizeDescription.Dimension.EXPAND,
+            heightDimension = WidgetSizeDescription.Dimension.WRAP)
+
+    @SuppressWarnings
+    override fun getWidgetStateUpdate(): Flowable<ModelState> {
+        return super.getWidgetStateUpdate()
+    }
+
+    /** Widget state updates for [LaserRangeWidget] */
+    sealed class ModelState {
+        data class ProductConnected(val boolean: Boolean) : ModelState()
+        data class RangeStateUpdated(val rangeState: RangeState) : ModelState()
+    }
+}

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidgetModel.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidgetModel.kt
@@ -1,0 +1,66 @@
+package dji.v5.ux.core.widget.laserrange
+
+import dji.sdk.keyvalue.key.CameraKey
+import dji.sdk.keyvalue.key.KeyTools
+import dji.sdk.keyvalue.value.camera.LaserMeasureInformation
+import dji.v5.ux.core.base.DJISDKModel
+import dji.v5.ux.core.base.WidgetModel
+import dji.v5.ux.core.communication.ObservableInMemoryKeyedStore
+import dji.v5.ux.core.util.DataProcessor
+import io.reactivex.rxjava3.core.Flowable
+
+/**
+ * Widget Model for the [LaserRangeWidget] used to access the camera laser range finder data.
+ */
+class LaserRangeWidgetModel(
+    djiSdkModel: DJISDKModel,
+    keyedStore: ObservableInMemoryKeyedStore
+) : WidgetModel(djiSdkModel, keyedStore) {
+
+    private val laserInfoProcessor = DataProcessor.create<LaserMeasureInformation?>(null)
+    private val rangeStateProcessor = DataProcessor.create<RangeState>(RangeState.ProductDisconnected)
+
+    /**
+     * Range finder state containing the measured distance if available.
+     */
+    val rangeState: Flowable<RangeState>
+        get() = rangeStateProcessor.toFlowable()
+
+    override fun inSetup() {
+        bindDataProcessor(
+            KeyTools.createCameraKey(CameraKey.KeyLaserMeasureInformation),
+            laserInfoProcessor
+        )
+    }
+
+    override fun updateStates() {
+        if (productConnectionProcessor.value) {
+            val info = laserInfoProcessor.value
+            if (info != null) {
+                rangeStateProcessor.onNext(RangeState.CurrentRange(info.distance))
+            } else {
+                rangeStateProcessor.onNext(RangeState.RangeUnavailable)
+            }
+        } else {
+            rangeStateProcessor.onNext(RangeState.ProductDisconnected)
+        }
+    }
+
+    override fun inCleanup() {
+        // Nothing to clean
+    }
+
+    /**
+     * Class representing range finder state.
+     */
+    sealed class RangeState {
+        /** Product is disconnected */
+        object ProductDisconnected : RangeState()
+
+        /** Range finder data unavailable */
+        object RangeUnavailable : RangeState()
+
+        /** Current range value from the laser sensor */
+        data class CurrentRange(val distance: Double) : RangeState()
+    }
+}

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/showcase/widgetlist/WidgetsActivity.java
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/showcase/widgetlist/WidgetsActivity.java
@@ -99,6 +99,7 @@ import dji.v5.ux.core.widget.useraccount.UserAccountLoginWidget;
 import dji.v5.ux.core.widget.verticalvelocity.VerticalVelocityWidget;
 import dji.v5.ux.core.widget.videosignal.VideoSignalWidget;
 import dji.v5.ux.core.widget.vps.VPSWidget;
+import dji.v5.ux.core.widget.laserrange.LaserRangeWidget;
 import dji.v5.ux.flight.flightparam.DistanceLimitWidget;
 import dji.v5.ux.flight.flightparam.FlightModeWidget;
 import dji.v5.ux.flight.flightparam.LedWidget;
@@ -237,6 +238,7 @@ public class WidgetsActivity extends AppCompatActivity implements WidgetListFrag
         widgetListItems.add(new WidgetListItem(R.string.uxsdk_user_account_login_widget_title, new WidgetViewHolder<>(UserAccountLoginWidget.class,
                 240, 60)));
         widgetListItems.add(new WidgetListItem(R.string.uxsdk_vertical_velocity_widget_title, new WidgetViewHolder<>(VerticalVelocityWidget.class)));
+        widgetListItems.add(new WidgetListItem(R.string.uxsdk_laser_range_widget_title, new WidgetViewHolder<>(dji.v5.ux.core.widget.laserrange.LaserRangeWidget.class)));
         widgetListItems.add(new WidgetListItem(R.string.uxsdk_vision_widget_title, new WidgetViewHolder<>(PerceptionStateWidget.class)));
         widgetListItems.add(new WidgetListItem(R.string.uxsdk_video_signal_widget_title, new WidgetViewHolder<>(VideoSignalWidget.class, 86, 50)));
         widgetListItems.add(new WidgetListItem(R.string.uxsdk_vps_widget_title, new WidgetViewHolder<>(VPSWidget.class)));

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/values/strings.xml
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/values/strings.xml
@@ -73,6 +73,7 @@
     <string name="uxsdk_vps_title">VPS</string>
     <string name="uxsdk_horizontal_velocity_title">H.S.</string>
     <string name="uxsdk_vertical_velocity_title">V.S.</string>
+    <string name="uxsdk_laser_range_title">Laser</string>
 
     <string name="uxsdk_video_time_hours">%1$02d:%2$02d:%3$02d</string>
     <string name="uxsdk_video_time">%1$02d:%2$02d</string>
@@ -446,6 +447,7 @@
     <string name="uxsdk_top_bar_panel_title">Top Bar Panel</string>
     <string name="uxsdk_user_account_login_widget_title">User Account Login Widget</string>
     <string name="uxsdk_vertical_velocity_widget_title">Vertical Velocity Widget</string>
+    <string name="uxsdk_laser_range_widget_title">Laser Range Widget</string>
     <string name="uxsdk_vision_widget_title">Vision Widget</string>
     <string name="uxsdk_vps_widget_title">VPS Widget</string>
     <string name="uxsdk_flight_mode_widget_title">Flight Mode Widget</string>

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/values/styles.xml
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/values/styles.xml
@@ -197,6 +197,10 @@
         <item name="uxsdk_label_string">@string/uxsdk_vertical_velocity_title</item>
     </style>
 
+    <style name="UXSDKLaserRangeWidget">
+        <item name="uxsdk_label_string">@string/uxsdk_laser_range_title</item>
+    </style>
+
     <style name="UXSDKVPSWidget">
         <item name="uxsdk_label_string">@string/uxsdk_vps_title</item>
     </style>


### PR DESCRIPTION
## Summary
- add `LaserRangeWidget` and associated model to show the laser range finder distance
- expose the widget in the sample's widget list
- add new string and style resources for the new widget

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685e98e7c6dc8323a764d9f58cbfbd9e