### PR TITLE
Add Laser Range Finder widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Sample module:
 - sample：Compile aircraft sample App, which depends on uxsdk.
 - Laser range sample: open the **Laser Range Widget** from the widget list to display the H20 camera's range finder distance.
 - H20 camera preview: from the sample's main screen choose **Multi-Video Decoding (CameraStreamManager - New)** to watch the live camera feed while the gimbal pans and zooms.
-- RTSP streaming: the widget list automatically starts an RTSP server at `rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1` so you can view the feed remotely while the camera pans and zooms.
-- Remote control server: `WidgetsActivity` also listens on TCP port `8989` to receive commands and report range finder distance and GPS. An example Python client is available in `scripts/control_camera_client.py`.
+- RTSP streaming: the application starts an RTSP server at `rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1` so you can view the feed remotely while the camera pans and zooms.
+- Remote control server: the app listens on TCP port `8989` to receive commands and report range finder distance and GPS. An example Python client is available in `scripts/control_camera_client.py`.
 
 ## Integration
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Sample module:
 - Laser range sample: open the **Laser Range Widget** from the widget list to display the H20 camera's range finder distance.
 - H20 camera preview: from the sample's main screen choose **Multi-Video Decoding (CameraStreamManager - New)** to watch the live camera feed while the gimbal pans and zooms.
 - RTSP streaming: the application starts an RTSP server at `rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1` so you can view the feed remotely while the camera pans and zooms.
-- Remote control server: the app listens on TCP port `8989` to receive commands and report range finder distance and GPS. An example Python client is available in `scripts/control_camera_client.py`.
+- Remote control server: the app listens on TCP port `8989` to receive commands and report range finder distance and GPS. An example Python client that also displays the RTSP feed using OpenCV is available in `scripts/control_camera_client.py`.
 
 ## Integration
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Sample module:
 - sample：Compile aircraft sample App, which depends on uxsdk.
 - Laser range sample: open the **Laser Range Widget** from the widget list to display the H20 camera's range finder distance.
 - H20 camera preview: from the sample's main screen choose **Multi-Video Decoding (CameraStreamManager - New)** to watch the live camera feed while the gimbal pans and zooms.
+- RTSP streaming: the widget list automatically starts an RTSP server at `rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1` so you can view the feed remotely while the camera pans and zooms.
 
 ## Integration
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ Sample module:
 
 - sample：Compile aircraft sample App, which depends on uxsdk.
 - Laser range sample: open the **Laser Range Widget** from the widget list to display the H20 camera's range finder distance.
-- H20 camera preview: from the sample's main screen choose **Multi-Video Decoding (CameraStreamManager - New)** to watch the live camera feed while the gimbal pans and zooms.
-- RTSP streaming: the application starts an RTSP server at `rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1` so you can view the feed remotely while the camera pans and zooms.
-- Remote control server: the app listens on TCP port `8989` to receive commands and report range finder distance and GPS. An example Python client that also displays the RTSP feed using OpenCV is available in `scripts/control_camera_client.py`.
+ - H20 camera preview: from the sample's main screen choose **Multi-Video Decoding (CameraStreamManager - New)** to watch the live camera feed.
+ - RTSP streaming: the application starts an RTSP server at `rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1` so you can view the feed remotely. Control the gimbal and zoom via the TCP server.
+ - Remote control server: the app listens on TCP port `8989` to receive commands and report range finder distance and GPS. An example Python client that also displays the RTSP feed using OpenCV is available in `scripts/control_camera_client.py`.
 
 ## Integration
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Sample module:
 
 - sample：Compile aircraft sample App, which depends on uxsdk.
 - Laser range sample: open the **Laser Range Widget** from the widget list to display the H20 camera's range finder distance.
+- H20 camera preview: from the sample's main screen choose **Multi-Video Decoding (CameraStreamManager - New)** to watch the live camera feed while the gimbal pans and zooms.
 
 ## Integration
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Sample module:
 - sample：Compile aircraft sample App, which depends on uxsdk.
 - Laser range sample: open the **Laser Range Widget** from the widget list to display the H20 camera's range finder distance.
  - H20 camera preview: from the sample's main screen choose **Multi-Video Decoding (CameraStreamManager - New)** to watch the live camera feed.
- - RTSP streaming: the application starts an RTSP server at `rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1` so you can view the feed remotely. Control the gimbal and zoom via the TCP server.
+- RTSP streaming: the application starts an RTSP server at `rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1` so you can view the feed remotely. Control the gimbal and zoom via the TCP server.
+  The stream uses the camera's zoom lens so changes to zoom ratio are reflected in the video.
  - Remote control server: the app listens on TCP port `8989` to receive commands and report range finder distance and GPS. An example Python client that also displays the RTSP feed using OpenCV is available in `scripts/control_camera_client.py`.
 
 ## Integration

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Sample module:
  - H20 camera preview: from the sample's main screen choose **Multi-Video Decoding (CameraStreamManager - New)** to watch the live camera feed.
 - RTSP streaming: the application starts an RTSP server at `rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1` so you can view the feed remotely. Control the gimbal and zoom via the TCP server.
   The stream uses the camera's zoom lens so changes to zoom ratio are reflected in the video.
- - Remote control server: the app listens on TCP port `8989` to receive commands and report range finder distance and GPS. The range finder value is polled every half second so GET commands always return the latest measurement. An example Python client that also displays the RTSP feed using OpenCV is available in `scripts/control_camera_client.py`.
+ - Remote control server: the app listens on TCP port `8989` to receive commands and report laser range finder data. The server polls the sensor every half second so `GET` commands return the latest distance together with latitude, longitude, altitude and target point coordinates. An example Python client that also displays the RTSP feed using OpenCV is available in `scripts/control_camera_client.py`.
 
 ## Integration
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Scenographic Example：
 Sample module:
 
 - sample：Compile aircraft sample App, which depends on uxsdk.
+- Laser range sample: open the **Laser Range Widget** from the widget list to display the H20 camera's range finder distance.
 
 ## Integration
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Sample module:
 - Laser range sample: open the **Laser Range Widget** from the widget list to display the H20 camera's range finder distance.
 - H20 camera preview: from the sample's main screen choose **Multi-Video Decoding (CameraStreamManager - New)** to watch the live camera feed while the gimbal pans and zooms.
 - RTSP streaming: the widget list automatically starts an RTSP server at `rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1` so you can view the feed remotely while the camera pans and zooms.
+- Remote control server: `WidgetsActivity` also listens on TCP port `8989` to receive commands and report range finder distance and GPS. An example Python client is available in `scripts/control_camera_client.py`.
 
 ## Integration
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Sample module:
  - H20 camera preview: from the sample's main screen choose **Multi-Video Decoding (CameraStreamManager - New)** to watch the live camera feed.
 - RTSP streaming: the application starts an RTSP server at `rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1` so you can view the feed remotely. Control the gimbal and zoom via the TCP server.
   The stream uses the camera's zoom lens so changes to zoom ratio are reflected in the video.
- - Remote control server: the app listens on TCP port `8989` to receive commands and report range finder distance and GPS. An example Python client that also displays the RTSP feed using OpenCV is available in `scripts/control_camera_client.py`.
+ - Remote control server: the app listens on TCP port `8989` to receive commands and report range finder distance and GPS. The range finder value is polled every half second so GET commands always return the latest measurement. An example Python client that also displays the RTSP feed using OpenCV is available in `scripts/control_camera_client.py`.
 
 ## Integration
 

--- a/SampleCode-V5/android-sdk-v5-as/build.gradle
+++ b/SampleCode-V5/android-sdk-v5-as/build.gradle
@@ -14,6 +14,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
+        classpath 'com.chaquo.python:gradle:14.0.2'
     }
 }
 

--- a/SampleCode-V5/android-sdk-v5-sample/build.gradle
+++ b/SampleCode-V5/android-sdk-v5-sample/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'com.chaquo.python'
 
 android {
     compileSdkVersion Integer.parseInt(project.ANDROID_COMPILE_SDK_VERSION)
@@ -98,6 +99,18 @@ android {
 
     buildFeatures {
         viewBinding true
+    }
+}
+
+python {
+    // Include Python sources from src/main/python
+    sourceSets {
+        main {
+            python.srcDir "src/main/python"
+        }
+    }
+    pip {
+        install "jnius"
     }
 }
 

--- a/SampleCode-V5/android-sdk-v5-sample/src/main/java/com/dji/sampleV5/aircraft/MainActivity.java
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/java/com/dji/sampleV5/aircraft/MainActivity.java
@@ -16,7 +16,7 @@ public class MainActivity extends AppCompatActivity {
             Python.start(new AndroidPlatform(this));
         }
         Python py = Python.getInstance();
-        py.getModule("drone_control").callAttr("go_to_waypoint",
-                22.5362, 113.9454, 20.0);
+        // For initial testing, simply fly to a set altitude using Python
+        py.getModule("drone_control").callAttr("fly_to_altitude", 20.0);
     }
 }

--- a/SampleCode-V5/android-sdk-v5-sample/src/main/java/com/dji/sampleV5/aircraft/MainActivity.java
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/java/com/dji/sampleV5/aircraft/MainActivity.java
@@ -1,0 +1,22 @@
+package com.dji.sampleV5.aircraft;
+
+import android.os.Bundle;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.chaquo.python.Python;
+import com.chaquo.python.android.AndroidPlatform;
+
+public class MainActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (!Python.isStarted()) {
+            Python.start(new AndroidPlatform(this));
+        }
+        Python py = Python.getInstance();
+        py.getModule("drone_control").callAttr("go_to_waypoint",
+                22.5362, 113.9454, 20.0);
+    }
+}

--- a/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/DJIApplication.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/DJIApplication.kt
@@ -3,9 +3,9 @@ package dji.sampleV5.aircraft
 import android.app.Application
 import dji.sampleV5.aircraft.models.MSDKManagerVM
 import dji.sampleV5.aircraft.models.globalViewModels
-import dji.v5.ux.sample.util.PanAndZoomUtil
 import dji.v5.ux.sample.util.RtspStreamUtil
 import dji.v5.ux.sample.util.RangeControlServer
+import androidx.lifecycle.Observer
 
 /**
  * Class Description
@@ -18,6 +18,13 @@ import dji.v5.ux.sample.util.RangeControlServer
 open class DJIApplication : Application() {
 
     private val msdkManagerVM: MSDKManagerVM by globalViewModels()
+    private val connectionObserver = Observer<Pair<Boolean, Int>> { resultPair ->
+        if (resultPair.first) {
+            RtspStreamUtil.start("rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1")
+        } else {
+            RtspStreamUtil.stop()
+        }
+    }
 
     override fun onCreate() {
         super.onCreate()
@@ -25,15 +32,14 @@ open class DJIApplication : Application() {
         // Ensure initialization is called first
         msdkManagerVM.initMobileSDK(this)
 
-        // Start demo camera controls and streaming so they persist across activities
-        PanAndZoomUtil.start()
-        RtspStreamUtil.start("rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1")
+        // Start servers for remote control and video streaming
+        msdkManagerVM.lvProductConnectionState.observeForever(connectionObserver)
         RangeControlServer.start()
     }
 
     override fun onTerminate() {
+        msdkManagerVM.lvProductConnectionState.removeObserver(connectionObserver)
         RtspStreamUtil.stop()
-        PanAndZoomUtil.stop()
         RangeControlServer.stop()
         super.onTerminate()
     }

--- a/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/DJIApplication.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/DJIApplication.kt
@@ -5,6 +5,7 @@ import dji.sampleV5.aircraft.models.MSDKManagerVM
 import dji.sampleV5.aircraft.models.globalViewModels
 import dji.v5.ux.sample.util.PanAndZoomUtil
 import dji.v5.ux.sample.util.RtspStreamUtil
+import dji.v5.ux.sample.util.RangeControlServer
 
 /**
  * Class Description
@@ -23,11 +24,17 @@ open class DJIApplication : Application() {
 
         // Ensure initialization is called first
         msdkManagerVM.initMobileSDK(this)
+
+        // Start demo camera controls and streaming so they persist across activities
+        PanAndZoomUtil.start()
+        RtspStreamUtil.start("rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1")
+        RangeControlServer.start()
     }
 
     override fun onTerminate() {
         RtspStreamUtil.stop()
         PanAndZoomUtil.stop()
+        RangeControlServer.stop()
         super.onTerminate()
     }
 

--- a/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/DJIApplication.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/DJIApplication.kt
@@ -3,6 +3,8 @@ package dji.sampleV5.aircraft
 import android.app.Application
 import dji.sampleV5.aircraft.models.MSDKManagerVM
 import dji.sampleV5.aircraft.models.globalViewModels
+import dji.v5.ux.sample.util.PanAndZoomUtil
+import dji.v5.ux.sample.util.RtspStreamUtil
 
 /**
  * Class Description
@@ -21,6 +23,12 @@ open class DJIApplication : Application() {
 
         // Ensure initialization is called first
         msdkManagerVM.initMobileSDK(this)
+    }
+
+    override fun onTerminate() {
+        RtspStreamUtil.stop()
+        PanAndZoomUtil.stop()
+        super.onTerminate()
     }
 
 }

--- a/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/models/CameraStreamDetailVM.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/models/CameraStreamDetailVM.kt
@@ -43,6 +43,7 @@ class CameraStreamDetailVM : DJIViewModel() {
     private val _visionAssistViewDirection = MutableLiveData(VisionAssistDirection.UNKNOWN)
     private val _visionAssistViewDirectionRange = MutableLiveData<List<VisionAssistDirection>>(ArrayList())
     val cameraStreamEnableMap = MutableLiveData(emptyMap<ComponentIndexType, Boolean>())
+    private val _laserMeasureDistance = MutableLiveData<Double>()
 
     private var cameraIndex = ComponentIndexType.UNKNOWN
     private var cameraType = ""
@@ -100,6 +101,7 @@ class CameraStreamDetailVM : DJIViewModel() {
         MediaDataCenter.getInstance().cameraStreamManager.removeVisionAssistStatusListener(visionAssistStatusListener)
         KeyManager.getInstance().cancelListen(this)
         doStopDownloadStreamToLocal()
+        CameraKey.KeyLaserMeasureEnabled.create(cameraIndex).set(false)
     }
 
     fun setCameraIndex(cameraIndex: ComponentIndexType) {
@@ -115,6 +117,7 @@ class CameraStreamDetailVM : DJIViewModel() {
         listenAvailableLens()
         listenCurrentLens()
         listenVisionAssistStatus()
+        listenLaserMeasureInfo()
         MediaDataCenter.getInstance().cameraStreamManager.addAvailableCameraUpdatedListener(availableCameraUpdatedListener)
     }
 
@@ -177,6 +180,18 @@ class CameraStreamDetailVM : DJIViewModel() {
 
     private fun listenVisionAssistStatus() {
         MediaDataCenter.getInstance().cameraStreamManager.addVisionAssistStatusListener(visionAssistStatusListener)
+    }
+
+    private fun listenLaserMeasureInfo() {
+        if (cameraIndex == ComponentIndexType.UNKNOWN) {
+            return
+        }
+        // Enable laser measure module
+        CameraKey.KeyLaserMeasureEnabled.create(cameraIndex).set(true)
+        // Listen distance info
+        CameraKey.KeyLaserMeasureInformation.create(cameraIndex).listen(this) {
+            _laserMeasureDistance.postValue(it?.distance ?: -1.0)
+        }
     }
 
     fun changeCameraLens(lensType: CameraVideoStreamSourceType) {
@@ -311,4 +326,7 @@ class CameraStreamDetailVM : DJIViewModel() {
 
     val visionAssistViewDirectionRange: LiveData<List<VisionAssistDirection>>
         get() = _visionAssistViewDirectionRange
+
+    val laserMeasureDistance: LiveData<Double>
+        get() = _laserMeasureDistance
 }

--- a/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/pages/CameraStreamDetailFragment.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/pages/CameraStreamDetailFragment.kt
@@ -110,6 +110,13 @@ class CameraStreamDetailFragment : DJIFragment() {
         btnDownloadYUV = view.findViewById(R.id.btn_download_yuv)
         tvCameraName = view.findViewById(R.id.tv_camera_name)
         tvLaserDistance = view.findViewById(R.id.tv_laser_distance)
+        // Only the H20 camera provides laser distance values. Hide this
+        // view when displaying other camera feeds such as FPV or the vision
+        // assist camera.
+        if (cameraIndex == ComponentIndexType.FPV ||
+            cameraIndex == ComponentIndexType.VISION_ASSIST) {
+            tvLaserDistance.visibility = View.GONE
+        }
         btnCloseOrOpen = view.findViewById(R.id.btn_close_or_open)
         btnCloseOrOpenVisionAssist = view.findViewById(R.id.btn_vision_assist_close_or_open)
         btnBeginDownloadStream = view.findViewById(R.id.btn_begin_download_stream)

--- a/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/pages/CameraStreamDetailFragment.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/pages/CameraStreamDetailFragment.kt
@@ -62,6 +62,7 @@ class CameraStreamDetailFragment : DJIFragment() {
     private lateinit var cameraSurfaceView: SurfaceView
     private lateinit var btnDownloadYUV: Button
     private lateinit var tvCameraName: TextView
+    private lateinit var tvLaserDistance: TextView
     private lateinit var btnCloseOrOpen: Button
     private lateinit var btnCloseOrOpenVisionAssist: Button
     private lateinit var btnBeginDownloadStream: Button
@@ -108,6 +109,7 @@ class CameraStreamDetailFragment : DJIFragment() {
         cameraSurfaceView = view.findViewById(R.id.sv_camera)
         btnDownloadYUV = view.findViewById(R.id.btn_download_yuv)
         tvCameraName = view.findViewById(R.id.tv_camera_name)
+        tvLaserDistance = view.findViewById(R.id.tv_laser_distance)
         btnCloseOrOpen = view.findViewById(R.id.btn_close_or_open)
         btnCloseOrOpenVisionAssist = view.findViewById(R.id.btn_vision_assist_close_or_open)
         btnBeginDownloadStream = view.findViewById(R.id.btn_begin_download_stream)
@@ -217,6 +219,16 @@ class CameraStreamDetailFragment : DJIFragment() {
 
         viewModel.cameraName.observe(viewLifecycleOwner) { name ->
             tvCameraName.text = name
+        }
+
+        viewModel.laserMeasureDistance.observe(viewLifecycleOwner) {
+            val distance = it ?: -1.0
+            val text = if (distance >= 0) {
+                String.format("Laser Distance: %.1f m", distance)
+            } else {
+                "Laser Distance: --"
+            }
+            tvLaserDistance.text = text
         }
 
         viewModel.isVisionAssistEnabled.observe(viewLifecycleOwner) {

--- a/SampleCode-V5/android-sdk-v5-sample/src/main/python/drone_control.py
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/python/drone_control.py
@@ -26,3 +26,11 @@ def go_to_waypoint(lat, lon, alt):
         print('Start mission error:', error)
     else:
         print('Mission started')
+
+
+def fly_to_altitude(alt):
+    """Fly to the given altitude above the current location."""
+    # For testing we use the waypoint mission with a single point at the
+    # current coordinates. In a real application you would query the
+    # aircraft's current GPS position.
+    go_to_waypoint(22.5362, 113.9454, alt)

--- a/SampleCode-V5/android-sdk-v5-sample/src/main/python/drone_control.py
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/python/drone_control.py
@@ -1,0 +1,28 @@
+from jnius import autoclass
+
+# Autoclass DJI MSDK classes
+Waypoint = autoclass('dji.sdk.mission.waypoint.Waypoint')
+WaypointMissionBuilder = autoclass('dji.sdk.mission.waypoint.WaypointMission$Builder')
+MissionControl = autoclass('dji.sdk.mission.MissionControl')
+
+
+def go_to_waypoint(lat, lon, alt):
+    builder = WaypointMissionBuilder().waypointCount(1)
+    wp = Waypoint(lat, lon, alt)
+    builder.addWaypoint(wp)
+    mission = builder.build()
+
+    operator = MissionControl.getInstance().getWaypointMissionOperator()
+    error = operator.loadMission(mission)
+    if error:
+        print('Load mission error:', error)
+        return
+    error = operator.uploadMission()
+    if error:
+        print('Upload mission error:', error)
+        return
+    error = operator.startMission()
+    if error:
+        print('Start mission error:', error)
+    else:
+        print('Mission started')

--- a/SampleCode-V5/android-sdk-v5-sample/src/main/res/layout/fragment_camera_stream_detail.xml
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/res/layout/fragment_camera_stream_detail.xml
@@ -18,6 +18,15 @@
         android:textSize="13sp"
         android:textStyle="bold" />
 
+    <TextView
+        android:id="@+id/tv_laser_distance"
+        android:layout_width="wrap_content"
+        android:layout_height="24dp"
+        android:gravity="center"
+        android:textColor="@color/white"
+        android:textSize="13sp"
+        android:text="Laser Distance: --" />
+
     <SurfaceView
         android:id="@+id/sv_camera"
         android:layout_width="match_parent"

--- a/SampleCode-V5/android-sdk-v5-sample/src/main/res/layout/fragment_camera_stream_detail_single.xml
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/res/layout/fragment_camera_stream_detail_single.xml
@@ -26,6 +26,17 @@
             app:layout_constraintStart_toStartOf="@id/ll_live_info_layout"
             app:layout_constraintStart_toEndOf="@id/ll_live_info_layout"/>
 
+        <TextView
+            android:id="@+id/tv_laser_distance"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:textColor="@color/white"
+            android:text="Laser Distance: --"
+            android:textSize="15sp"
+            app:layout_constraintTop_toBottomOf="@id/tv_camera_name"
+            app:layout_constraintStart_toStartOf="@id/tv_camera_name"/>
+
         <androidx.core.widget.NestedScrollView
             android:id="@+id/ll_live_info_layout"
             android:layout_width="wrap_content"

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidget.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidget.kt
@@ -1,0 +1,100 @@
+package dji.v5.ux.core.widget.laserrange
+
+import android.content.Context
+import android.util.AttributeSet
+import io.reactivex.rxjava3.core.Flowable
+import dji.v5.ux.R
+import dji.v5.ux.core.base.DJISDKModel
+import dji.v5.ux.core.base.SchedulerProvider
+import dji.v5.ux.core.base.WidgetSizeDescription
+import dji.v5.ux.core.base.widget.BaseTelemetryWidget
+import dji.v5.ux.core.communication.ObservableInMemoryKeyedStore
+import dji.v5.ux.core.extension.getDistanceString
+import dji.v5.ux.core.extension.getString
+import dji.v5.ux.core.util.UnitConversionUtil
+import dji.v5.ux.core.widget.laserrange.LaserRangeWidget.ModelState
+import dji.v5.ux.core.widget.laserrange.LaserRangeWidgetModel.RangeState
+import java.text.DecimalFormat
+
+/**
+ * Widget that displays the distance measured by the camera laser range finder.
+ */
+open class LaserRangeWidget @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+    widgetTheme: Int = 0
+) : BaseTelemetryWidget<ModelState>(
+    context,
+    attrs,
+    defStyleAttr,
+    WidgetType.TEXT,
+    widgetTheme,
+    R.style.UXSDKLaserRangeWidget
+) {
+
+    override val metricDecimalFormat: DecimalFormat = DecimalFormat("###0.0")
+    override val imperialDecimalFormat: DecimalFormat = DecimalFormat("###0")
+
+    private val widgetModel: LaserRangeWidgetModel by lazy {
+        LaserRangeWidgetModel(
+            DJISDKModel.getInstance(),
+            ObservableInMemoryKeyedStore.getInstance()
+        )
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        if (!isInEditMode) {
+            widgetModel.setup()
+        }
+    }
+
+    override fun onDetachedFromWindow() {
+        if (!isInEditMode) {
+            widgetModel.cleanup()
+        }
+        super.onDetachedFromWindow()
+    }
+
+    override fun reactToModelChanges() {
+        addReaction(widgetModel.productConnection
+            .observeOn(SchedulerProvider.ui())
+            .subscribe { widgetStateDataProcessor.onNext(ModelState.ProductConnected(it)) })
+        addReaction(widgetModel.rangeState
+            .observeOn(SchedulerProvider.ui())
+            .subscribe { updateUI(it) })
+    }
+
+    private fun updateUI(state: RangeState) {
+        widgetStateDataProcessor.onNext(ModelState.RangeStateUpdated(state))
+        when (state) {
+            RangeState.ProductDisconnected, RangeState.RangeUnavailable -> {
+                valueString = getString(R.string.uxsdk_string_default_value)
+                unitString = null
+            }
+            is RangeState.CurrentRange -> {
+                valueString = getDecimalFormat(UnitConversionUtil.UnitType.METRIC).format(state.distance)
+                unitString = getDistanceString(UnitConversionUtil.UnitType.METRIC)
+            }
+        }
+    }
+
+    override fun getIdealDimensionRatioString(): String? = null
+
+    override val widgetSizeDescription: WidgetSizeDescription =
+        WidgetSizeDescription(WidgetSizeDescription.SizeType.OTHER,
+            widthDimension = WidgetSizeDescription.Dimension.EXPAND,
+            heightDimension = WidgetSizeDescription.Dimension.WRAP)
+
+    @SuppressWarnings
+    override fun getWidgetStateUpdate(): Flowable<ModelState> {
+        return super.getWidgetStateUpdate()
+    }
+
+    /** Widget state updates for [LaserRangeWidget] */
+    sealed class ModelState {
+        data class ProductConnected(val boolean: Boolean) : ModelState()
+        data class RangeStateUpdated(val rangeState: RangeState) : ModelState()
+    }
+}

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidgetModel.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidgetModel.kt
@@ -6,6 +6,7 @@ import dji.sdk.keyvalue.value.camera.LaserMeasureInformation
 import dji.sdk.keyvalue.value.common.CameraLensType
 import dji.sdk.keyvalue.value.common.ComponentIndexType
 import dji.v5.ux.core.base.ICameraIndex
+import dji.v5.manager.KeyManager
 import dji.v5.ux.core.base.DJISDKModel
 import dji.v5.ux.core.base.WidgetModel
 import dji.v5.ux.core.communication.ObservableInMemoryKeyedStore
@@ -23,7 +24,7 @@ class LaserRangeWidgetModel(
     private var cameraIndex = ComponentIndexType.LEFT_OR_MAIN
     private var lensType = CameraLensType.CAMERA_LENS_ZOOM
 
-    private val laserInfoProcessor = DataProcessor.create(LaserMeasureInformation())
+    private val laserInfoProcessor = DataProcessor.create<LaserMeasureInformation?>(null)
     private val rangeStateProcessor = DataProcessor.create<RangeState>(RangeState.ProductDisconnected)
 
     /**
@@ -33,6 +34,16 @@ class LaserRangeWidgetModel(
         get() = rangeStateProcessor.toFlowable()
 
     override fun inSetup() {
+        // enable the laser module so measurements are available
+        KeyManager.getInstance().setValue(
+            KeyTools.createCameraKey(
+                CameraKey.KeyLaserMeasureEnabled,
+                cameraIndex,
+                lensType
+            ),
+            true,
+            null
+        )
         bindDataProcessor(
             KeyTools.createCameraKey(
                 CameraKey.KeyLaserMeasureInformation,
@@ -44,15 +55,16 @@ class LaserRangeWidgetModel(
     }
 
     override fun updateStates() {
-        if (productConnectionProcessor.value) {
-            val info = laserInfoProcessor.value
-            if (info.distance > 0) {
-                rangeStateProcessor.onNext(RangeState.CurrentRange(info.distance))
-            } else {
-                rangeStateProcessor.onNext(RangeState.RangeUnavailable)
-            }
-        } else {
+        if (!productConnectionProcessor.value) {
             rangeStateProcessor.onNext(RangeState.ProductDisconnected)
+            return
+        }
+
+        val info = laserInfoProcessor.value
+        if (info != null && info.distance > 0) {
+            rangeStateProcessor.onNext(RangeState.CurrentRange(info.distance))
+        } else {
+            rangeStateProcessor.onNext(RangeState.RangeUnavailable)
         }
     }
 

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidgetModel.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidgetModel.kt
@@ -24,7 +24,7 @@ class LaserRangeWidgetModel(
     private var cameraIndex = ComponentIndexType.LEFT_OR_MAIN
     private var lensType = CameraLensType.CAMERA_LENS_ZOOM
 
-    private val laserInfoProcessor = DataProcessor.create<LaserMeasureInformation?>(null)
+    private val laserInfoProcessor = DataProcessor.create(LaserMeasureInformation())
     private val rangeStateProcessor = DataProcessor.create<RangeState>(RangeState.ProductDisconnected)
 
     /**
@@ -61,7 +61,7 @@ class LaserRangeWidgetModel(
         }
 
         val info = laserInfoProcessor.value
-        if (info != null && info.distance > 0) {
+        if (info.distance > 0) {
             rangeStateProcessor.onNext(RangeState.CurrentRange(info.distance))
         } else {
             rangeStateProcessor.onNext(RangeState.RangeUnavailable)

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidgetModel.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidgetModel.kt
@@ -34,7 +34,11 @@ class LaserRangeWidgetModel(
 
     override fun inSetup() {
         bindDataProcessor(
-            KeyTools.createCameraKey(CameraKey.KeyLaserMeasureInformation, cameraIndex),
+            KeyTools.createCameraKey(
+                CameraKey.KeyLaserMeasureInformation,
+                cameraIndex,
+                lensType
+            ),
             laserInfoProcessor
         )
     }

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidgetModel.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidgetModel.kt
@@ -1,0 +1,82 @@
+package dji.v5.ux.core.widget.laserrange
+
+import dji.sdk.keyvalue.key.CameraKey
+import dji.sdk.keyvalue.key.KeyTools
+import dji.sdk.keyvalue.value.camera.LaserMeasureInformation
+import dji.sdk.keyvalue.value.common.CameraLensType
+import dji.sdk.keyvalue.value.common.ComponentIndexType
+import dji.v5.ux.core.base.ICameraIndex
+import dji.v5.ux.core.base.DJISDKModel
+import dji.v5.ux.core.base.WidgetModel
+import dji.v5.ux.core.communication.ObservableInMemoryKeyedStore
+import dji.v5.ux.core.util.DataProcessor
+import io.reactivex.rxjava3.core.Flowable
+
+/**
+ * Widget Model for the [LaserRangeWidget] used to access the camera laser range finder data.
+ */
+class LaserRangeWidgetModel(
+    djiSdkModel: DJISDKModel,
+    keyedStore: ObservableInMemoryKeyedStore
+) : WidgetModel(djiSdkModel, keyedStore), ICameraIndex {
+
+    private var cameraIndex = ComponentIndexType.LEFT_OR_MAIN
+    private var lensType = CameraLensType.CAMERA_LENS_ZOOM
+
+    private val laserInfoProcessor = DataProcessor.create(LaserMeasureInformation())
+    private val rangeStateProcessor = DataProcessor.create<RangeState>(RangeState.ProductDisconnected)
+
+    /**
+     * Range finder state containing the measured distance if available.
+     */
+    val rangeState: Flowable<RangeState>
+        get() = rangeStateProcessor.toFlowable()
+
+    override fun inSetup() {
+        bindDataProcessor(
+            KeyTools.createCameraKey(CameraKey.KeyLaserMeasureInformation, cameraIndex, lensType),
+            laserInfoProcessor
+        )
+    }
+
+    override fun updateStates() {
+        if (productConnectionProcessor.value) {
+            val info = laserInfoProcessor.value
+            if (info.distance > 0) {
+                rangeStateProcessor.onNext(RangeState.CurrentRange(info.distance))
+            } else {
+                rangeStateProcessor.onNext(RangeState.RangeUnavailable)
+            }
+        } else {
+            rangeStateProcessor.onNext(RangeState.ProductDisconnected)
+        }
+    }
+
+    override fun inCleanup() {
+        // Nothing to clean
+    }
+
+    override fun getCameraIndex(): ComponentIndexType = cameraIndex
+
+    override fun getLensType(): CameraLensType = lensType
+
+    override fun updateCameraSource(cameraIndex: ComponentIndexType, lensType: CameraLensType) {
+        this.cameraIndex = cameraIndex
+        this.lensType = lensType
+        restart()
+    }
+
+    /**
+     * Class representing range finder state.
+     */
+    sealed class RangeState {
+        /** Product is disconnected */
+        object ProductDisconnected : RangeState()
+
+        /** Range finder data unavailable */
+        object RangeUnavailable : RangeState()
+
+        /** Current range value from the laser sensor */
+        data class CurrentRange(val distance: Double) : RangeState()
+    }
+}

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidgetModel.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidgetModel.kt
@@ -34,7 +34,7 @@ class LaserRangeWidgetModel(
 
     override fun inSetup() {
         bindDataProcessor(
-            KeyTools.createCameraKey(CameraKey.KeyLaserMeasureInformation, cameraIndex, lensType),
+            KeyTools.createCameraKey(CameraKey.KeyLaserMeasureInformation, cameraIndex),
             laserInfoProcessor
         )
     }

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidgetModel.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/laserrange/LaserRangeWidgetModel.kt
@@ -60,8 +60,13 @@ class LaserRangeWidgetModel(
             return
         }
 
-        val info = laserInfoProcessor.value
-        if (info.distance > 0) {
+        val key = KeyTools.createCameraKey(
+            CameraKey.KeyLaserMeasureInformation,
+            cameraIndex,
+            lensType
+        )
+        val info = KeyManager.getInstance().getValue<LaserMeasureInformation>(key)
+        if (info != null && info.distance > 0) {
             rangeStateProcessor.onNext(RangeState.CurrentRange(info.distance))
         } else {
             rangeStateProcessor.onNext(RangeState.RangeUnavailable)

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/showcase/widgetlist/WidgetsActivity.java
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/showcase/widgetlist/WidgetsActivity.java
@@ -127,6 +127,7 @@ import dji.v5.ux.visualcamera.zoom.FocalZoomWidget;
 import dji.v5.ux.warning.DeviceHealthAndStatusWidget;
 import dji.v5.ux.sample.util.PanAndZoomUtil;
 import dji.v5.ux.sample.util.RtspStreamUtil;
+import dji.v5.ux.sample.util.RangeControlServer;
 
 /**
  * Displays a list of widget names. Clicking on a widget name will show that widget in a separate
@@ -143,6 +144,7 @@ public class WidgetsActivity extends AppCompatActivity implements WidgetListFrag
 
         PanAndZoomUtil.start();
         RtspStreamUtil.start("rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1");
+        RangeControlServer.start();
 
         View decorView = getWindow().getDecorView();
         decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY | View.SYSTEM_UI_FLAG_FULLSCREEN |
@@ -328,6 +330,9 @@ public class WidgetsActivity extends AppCompatActivity implements WidgetListFrag
 
     @Override
     protected void onDestroy() {
+        RangeControlServer.stop();
+        PanAndZoomUtil.stop();
+        RtspStreamUtil.stop();
         super.onDestroy();
     }
 }

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/showcase/widgetlist/WidgetsActivity.java
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/showcase/widgetlist/WidgetsActivity.java
@@ -99,6 +99,7 @@ import dji.v5.ux.core.widget.useraccount.UserAccountLoginWidget;
 import dji.v5.ux.core.widget.verticalvelocity.VerticalVelocityWidget;
 import dji.v5.ux.core.widget.videosignal.VideoSignalWidget;
 import dji.v5.ux.core.widget.vps.VPSWidget;
+import dji.v5.ux.core.widget.laserrange.LaserRangeWidget;
 import dji.v5.ux.flight.flightparam.DistanceLimitWidget;
 import dji.v5.ux.flight.flightparam.FlightModeWidget;
 import dji.v5.ux.flight.flightparam.LedWidget;
@@ -124,6 +125,7 @@ import dji.v5.ux.visualcamera.storage.CameraConfigStorageWidget;
 import dji.v5.ux.visualcamera.wb.CameraConfigWBWidget;
 import dji.v5.ux.visualcamera.zoom.FocalZoomWidget;
 import dji.v5.ux.warning.DeviceHealthAndStatusWidget;
+import dji.v5.ux.sample.util.PanAndZoomUtil;
 
 /**
  * Displays a list of widget names. Clicking on a widget name will show that widget in a separate
@@ -137,6 +139,8 @@ public class WidgetsActivity extends AppCompatActivity implements WidgetListFrag
         super.onCreate(savedInstanceState);
         populateList();
         setContentView(R.layout.uxsdk_activity_widgets);
+
+        PanAndZoomUtil.start();
 
         View decorView = getWindow().getDecorView();
         decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY | View.SYSTEM_UI_FLAG_FULLSCREEN |
@@ -237,6 +241,7 @@ public class WidgetsActivity extends AppCompatActivity implements WidgetListFrag
         widgetListItems.add(new WidgetListItem(R.string.uxsdk_user_account_login_widget_title, new WidgetViewHolder<>(UserAccountLoginWidget.class,
                 240, 60)));
         widgetListItems.add(new WidgetListItem(R.string.uxsdk_vertical_velocity_widget_title, new WidgetViewHolder<>(VerticalVelocityWidget.class)));
+        widgetListItems.add(new WidgetListItem(R.string.uxsdk_laser_range_widget_title, new WidgetViewHolder<>(dji.v5.ux.core.widget.laserrange.LaserRangeWidget.class)));
         widgetListItems.add(new WidgetListItem(R.string.uxsdk_vision_widget_title, new WidgetViewHolder<>(PerceptionStateWidget.class)));
         widgetListItems.add(new WidgetListItem(R.string.uxsdk_video_signal_widget_title, new WidgetViewHolder<>(VideoSignalWidget.class, 86, 50)));
         widgetListItems.add(new WidgetListItem(R.string.uxsdk_vps_widget_title, new WidgetViewHolder<>(VPSWidget.class)));
@@ -317,5 +322,11 @@ public class WidgetsActivity extends AppCompatActivity implements WidgetListFrag
         transaction.replace(R.id.fragment_container, newFragment);
         transaction.addToBackStack(null);
         transaction.commit();
+    }
+
+    @Override
+    protected void onDestroy() {
+        PanAndZoomUtil.stop();
+        super.onDestroy();
     }
 }

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/showcase/widgetlist/WidgetsActivity.java
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/showcase/widgetlist/WidgetsActivity.java
@@ -125,9 +125,6 @@ import dji.v5.ux.visualcamera.storage.CameraConfigStorageWidget;
 import dji.v5.ux.visualcamera.wb.CameraConfigWBWidget;
 import dji.v5.ux.visualcamera.zoom.FocalZoomWidget;
 import dji.v5.ux.warning.DeviceHealthAndStatusWidget;
-import dji.v5.ux.sample.util.PanAndZoomUtil;
-import dji.v5.ux.sample.util.RtspStreamUtil;
-import dji.v5.ux.sample.util.RangeControlServer;
 
 /**
  * Displays a list of widget names. Clicking on a widget name will show that widget in a separate
@@ -142,9 +139,6 @@ public class WidgetsActivity extends AppCompatActivity implements WidgetListFrag
         populateList();
         setContentView(R.layout.uxsdk_activity_widgets);
 
-        PanAndZoomUtil.start();
-        RtspStreamUtil.start("rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1");
-        RangeControlServer.start();
 
         View decorView = getWindow().getDecorView();
         decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY | View.SYSTEM_UI_FLAG_FULLSCREEN |
@@ -328,11 +322,4 @@ public class WidgetsActivity extends AppCompatActivity implements WidgetListFrag
         transaction.commit();
     }
 
-    @Override
-    protected void onDestroy() {
-        RangeControlServer.stop();
-        PanAndZoomUtil.stop();
-        RtspStreamUtil.stop();
-        super.onDestroy();
-    }
 }

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/showcase/widgetlist/WidgetsActivity.java
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/showcase/widgetlist/WidgetsActivity.java
@@ -126,6 +126,7 @@ import dji.v5.ux.visualcamera.wb.CameraConfigWBWidget;
 import dji.v5.ux.visualcamera.zoom.FocalZoomWidget;
 import dji.v5.ux.warning.DeviceHealthAndStatusWidget;
 import dji.v5.ux.sample.util.PanAndZoomUtil;
+import dji.v5.ux.sample.util.RtspStreamUtil;
 
 /**
  * Displays a list of widget names. Clicking on a widget name will show that widget in a separate
@@ -141,6 +142,7 @@ public class WidgetsActivity extends AppCompatActivity implements WidgetListFrag
         setContentView(R.layout.uxsdk_activity_widgets);
 
         PanAndZoomUtil.start();
+        RtspStreamUtil.start("rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1");
 
         View decorView = getWindow().getDecorView();
         decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY | View.SYSTEM_UI_FLAG_FULLSCREEN |
@@ -326,7 +328,6 @@ public class WidgetsActivity extends AppCompatActivity implements WidgetListFrag
 
     @Override
     protected void onDestroy() {
-        PanAndZoomUtil.stop();
         super.onDestroy();
     }
 }

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/PanAndZoomUtil.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/PanAndZoomUtil.kt
@@ -21,6 +21,7 @@ object PanAndZoomUtil {
 
     /** Start rotating the gimbal from -50° to +50° in 5° steps every 3 seconds.
      *  Each step increases the zoom ratio by 2. */
+    @JvmStatic
     fun start() {
         val rotateKey = KeyTools.createKey(GimbalKey.KeyRotateByAngle, ComponentIndexType.LEFT_OR_MAIN)
         val zoomKey = KeyTools.createCameraKey(
@@ -52,6 +53,7 @@ object PanAndZoomUtil {
     }
 
     /** Stop the pan and zoom routine. */
+    @JvmStatic
     fun stop() {
         disposables.clear()
     }

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/PanAndZoomUtil.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/PanAndZoomUtil.kt
@@ -1,0 +1,58 @@
+package dji.v5.ux.sample.util
+
+import dji.sdk.keyvalue.key.CameraKey
+import dji.sdk.keyvalue.key.GimbalKey
+import dji.sdk.keyvalue.key.KeyManager
+import dji.sdk.keyvalue.key.KeyTools
+import dji.sdk.keyvalue.value.camera.CameraLensType
+import dji.sdk.keyvalue.value.common.ComponentIndexType
+import dji.sdk.keyvalue.value.gimbal.GimbalAngleRotation
+import dji.sdk.keyvalue.value.gimbal.GimbalAngleRotationMode
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.schedulers.Schedulers
+import java.util.concurrent.TimeUnit
+
+/**
+ * Utility to slowly pan the gimbal and zoom the camera.
+ */
+object PanAndZoomUtil {
+    private val disposables = CompositeDisposable()
+
+    /** Start rotating the gimbal from -50° to +50° in 5° steps every 3 seconds.
+     *  Each step increases the zoom ratio by 2. */
+    fun start() {
+        val rotateKey = KeyTools.createKey(GimbalKey.KeyRotateByAngle, ComponentIndexType.LEFT_OR_MAIN)
+        val zoomKey = KeyTools.createCameraKey(
+            CameraKey.KeyCameraZoomRatios,
+            ComponentIndexType.LEFT_OR_MAIN,
+            CameraLensType.CAMERA_LENS_ZOOM
+        )
+
+        disposables.clear()
+        var yaw = -50
+        var zoom = 1.0
+
+        disposables.add(
+            Observable.interval(0, 3, TimeUnit.SECONDS)
+                .takeWhile { yaw <= 50 }
+                .observeOn(Schedulers.io())
+                .subscribe {
+                    val rotation = GimbalAngleRotation().apply {
+                        setMode(GimbalAngleRotationMode.ABSOLUTE_ANGLE)
+                        setYaw(yaw.toDouble())
+                        setDuration(2.0)
+                    }
+                    KeyManager.getInstance().performAction(rotateKey, rotation, null)
+                    KeyManager.getInstance().setValue(zoomKey, zoom, null)
+                    yaw += 5
+                    zoom += 2.0
+                }
+        )
+    }
+
+    /** Stop the pan and zoom routine. */
+    fun stop() {
+        disposables.clear()
+    }
+}

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/PanAndZoomUtil.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/PanAndZoomUtil.kt
@@ -2,9 +2,9 @@ package dji.v5.ux.sample.util
 
 import dji.sdk.keyvalue.key.CameraKey
 import dji.sdk.keyvalue.key.GimbalKey
-import dji.sdk.keyvalue.key.KeyManager
+import dji.v5.manager.KeyManager
 import dji.sdk.keyvalue.key.KeyTools
-import dji.sdk.keyvalue.value.camera.CameraLensType
+import dji.sdk.keyvalue.value.common.CameraLensType
 import dji.sdk.keyvalue.value.common.ComponentIndexType
 import dji.sdk.keyvalue.value.gimbal.GimbalAngleRotation
 import dji.sdk.keyvalue.value.gimbal.GimbalAngleRotationMode
@@ -39,9 +39,9 @@ object PanAndZoomUtil {
                 .observeOn(Schedulers.io())
                 .subscribe {
                     val rotation = GimbalAngleRotation().apply {
-                        setMode(GimbalAngleRotationMode.ABSOLUTE_ANGLE)
-                        setYaw(yaw.toDouble())
-                        setDuration(2.0)
+                        mode = GimbalAngleRotationMode.ABSOLUTE_ANGLE
+                        this.yaw = yaw.toDouble()
+                        duration = 2.0
                     }
                     KeyManager.getInstance().performAction(rotateKey, rotation, null)
                     KeyManager.getInstance().setValue(zoomKey, zoom, null)

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
@@ -76,15 +76,9 @@ object RangeControlServer {
     }
 
     private fun setZoomLens() {
-        val key = KeyTools.createCameraKey(
-            CameraKey.KeyCameraVideoStreamSource,
-            ComponentIndexType.LEFT_OR_MAIN
-        )
-        KeyManager.getInstance().setValue(
-            key,
-            CameraVideoStreamSourceType.ZOOM_CAMERA,
-            null
-        )
+        CameraKey.KeyCameraVideoStreamSource
+            .create(ComponentIndexType.LEFT_OR_MAIN)
+            .set(CameraVideoStreamSourceType.ZOOM_CAMERA)
     }
 
     private fun setOrientationAndZoom(yaw: Double, pitch: Double, zoom: Double) {

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
@@ -9,6 +9,7 @@ import dji.sdk.keyvalue.value.common.CameraLensType
 import dji.sdk.keyvalue.value.gimbal.GimbalAngleRotation
 import dji.sdk.keyvalue.value.gimbal.GimbalAngleRotationMode
 import dji.sdk.keyvalue.value.camera.LaserMeasureInformation
+import dji.sdk.keyvalue.value.camera.CameraVideoStreamSourceType
 import java.io.BufferedReader
 import java.io.BufferedWriter
 import java.io.InputStreamReader
@@ -31,6 +32,8 @@ object RangeControlServer {
     fun start(port: Int = 8989) {
         if (server != null) return
         server = ServerSocket(port)
+        // switch the live stream to the zoom lens so zoom ratios are visible
+        setZoomLens()
         thread {
             while (!server!!.isClosed) {
                 try {
@@ -70,6 +73,18 @@ object RangeControlServer {
                 }
             }
         }
+    }
+
+    private fun setZoomLens() {
+        val key = KeyTools.createCameraKey(
+            CameraKey.KeyCameraVideoStreamSource,
+            ComponentIndexType.LEFT_OR_MAIN
+        )
+        KeyManager.getInstance().setValue(
+            key,
+            CameraVideoStreamSourceType.ZOOM_CAMERA,
+            null
+        )
     }
 
     private fun setOrientationAndZoom(yaw: Double, pitch: Double, zoom: Double) {

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
@@ -1,0 +1,111 @@
+package dji.v5.ux.sample.util
+
+import dji.v5.manager.KeyManager
+import dji.sdk.keyvalue.key.KeyTools
+import dji.sdk.keyvalue.key.GimbalKey
+import dji.sdk.keyvalue.key.CameraKey
+import dji.sdk.keyvalue.value.common.ComponentIndexType
+import dji.sdk.keyvalue.value.common.CameraLensType
+import dji.sdk.keyvalue.value.gimbal.GimbalAngleRotation
+import dji.sdk.keyvalue.value.gimbal.GimbalAngleRotationMode
+import dji.sdk.keyvalue.value.camera.LaserMeasureInformation
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.ServerSocket
+import java.net.Socket
+import kotlin.concurrent.thread
+
+/**
+ * Simple TCP server to receive camera control commands and send range finder data.
+ * Commands:
+ *   SET <yaw> <pitch> <zoom>  - set gimbal orientation and zoom ratio
+ *   GET                      - reply with RANGE <distance> LAT <lat> LON <lon>
+ */
+object RangeControlServer {
+    private var server: ServerSocket? = null
+
+    @JvmStatic
+    fun start(port: Int = 8989) {
+        if (server != null) return
+        server = ServerSocket(port)
+        thread {
+            while (!server!!.isClosed) {
+                try {
+                    val socket = server!!.accept()
+                    handleClient(socket)
+                } catch (_: Exception) {
+                }
+            }
+        }
+    }
+
+    private fun handleClient(socket: Socket) {
+        thread {
+            socket.use { sock ->
+                val reader = BufferedReader(InputStreamReader(sock.getInputStream()))
+                val writer = BufferedWriter(OutputStreamWriter(sock.getOutputStream()))
+                var line: String?
+                while (reader.readLine().also { line = it } != null) {
+                    val parts = line!!.trim().split(" ")
+                    when (parts[0].uppercase()) {
+                        "SET" -> if (parts.size >= 4) {
+                            val yaw = parts[1].toDoubleOrNull() ?: 0.0
+                            val pitch = parts[2].toDoubleOrNull() ?: 0.0
+                            val zoom = parts[3].toDoubleOrNull() ?: 1.0
+                            setOrientationAndZoom(yaw, pitch, zoom)
+                        }
+                        "GET" -> {
+                            val info = getLaserInfo()
+                            val distance = info?.distance ?: -1.0
+                            val loc = info?.location3D
+                            val lat = loc?.latitude ?: 0.0
+                            val lon = loc?.longitude ?: 0.0
+                            writer.write("RANGE $distance LAT $lat LON $lon\n")
+                            writer.flush()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun setOrientationAndZoom(yaw: Double, pitch: Double, zoom: Double) {
+        val rotateKey = KeyTools.createKey(GimbalKey.KeyRotateByAngle, ComponentIndexType.LEFT_OR_MAIN)
+        val rotation = GimbalAngleRotation().apply {
+            mode = GimbalAngleRotationMode.ABSOLUTE_ANGLE
+            this.yaw = yaw
+            this.pitch = pitch
+            duration = 2.0
+        }
+        KeyManager.getInstance().performAction(rotateKey, rotation, null)
+
+        val zoomKey = KeyTools.createCameraKey(
+            CameraKey.KeyCameraZoomRatios,
+            ComponentIndexType.LEFT_OR_MAIN,
+            CameraLensType.CAMERA_LENS_ZOOM
+        )
+        KeyManager.getInstance().setValue(zoomKey, zoom, null)
+    }
+
+    private fun getLaserInfo(): LaserMeasureInformation? {
+        val key = KeyTools.createCameraKey(
+            CameraKey.KeyLaserMeasureInformation,
+            ComponentIndexType.LEFT_OR_MAIN,
+            CameraLensType.CAMERA_LENS_ZOOM
+        )
+        return KeyManager.getInstance().getValue(key)
+    }
+
+    @JvmStatic
+    fun stop() {
+        try {
+            server?.close()
+        } catch (_: Exception) {
+        } finally {
+            server = null
+        }
+    }
+}
+

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
@@ -78,9 +78,14 @@ object RangeControlServer {
     private fun setZoomLens() {
         val key = KeyTools.createCameraKey(
             CameraKey.KeyCameraVideoStreamSource,
-            ComponentIndexType.LEFT_OR_MAIN
+            ComponentIndexType.LEFT_OR_MAIN,
+            CameraLensType.CAMERA_LENS_ZOOM
         )
-        KeyManager.getInstance().setValue(key, CameraVideoStreamSourceType.ZOOM_CAMERA, null)
+        KeyManager.getInstance().setValue(
+            key,
+            CameraVideoStreamSourceType.ZOOM_CAMERA,
+            null
+        )
     }
 
     private fun setOrientationAndZoom(yaw: Double, pitch: Double, zoom: Double) {

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
@@ -78,12 +78,20 @@ object RangeControlServer {
     }
 
     private fun setZoomLens() {
-        val key = CameraKey.KeyCameraVideoStreamSource.create(ComponentIndexType.LEFT_OR_MAIN)
+        val key = KeyTools.createCameraKey(
+            CameraKey.KeyCameraVideoStreamSource,
+            ComponentIndexType.LEFT_OR_MAIN,
+            CameraLensType.CAMERA_LENS_ZOOM
+        )
         KeyManager.getInstance().setValue(key, CameraVideoStreamSourceType.ZOOM_CAMERA, null)
     }
 
     private fun enableLaserModule() {
-        val key = CameraKey.KeyLaserMeasureEnabled.create(ComponentIndexType.LEFT_OR_MAIN)
+        val key = KeyTools.createCameraKey(
+            CameraKey.KeyLaserMeasureEnabled,
+            ComponentIndexType.LEFT_OR_MAIN,
+            CameraLensType.CAMERA_LENS_ZOOM
+        )
         KeyManager.getInstance().setValue(key, true, null)
     }
 
@@ -106,7 +114,11 @@ object RangeControlServer {
     }
 
     private fun getLaserInfo(): LaserMeasureInformation? {
-        val key = CameraKey.KeyLaserMeasureInformation.create(ComponentIndexType.LEFT_OR_MAIN)
+        val key = KeyTools.createCameraKey(
+            CameraKey.KeyLaserMeasureInformation,
+            ComponentIndexType.LEFT_OR_MAIN,
+            CameraLensType.CAMERA_LENS_ZOOM
+        )
         return KeyManager.getInstance().getValue(key)
     }
 

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
@@ -43,8 +43,8 @@ object RangeControlServer {
         // enable the laser range finder so distance values can be returned
         enableLaserModule()
         // listen for laser measurement updates
-        KeyManager.getInstance().listen(laserInfoKey, this) { value: LaserMeasureInformation? ->
-            laserInfo = value
+        KeyManager.getInstance().listen(laserInfoKey, this) { _, newValue: LaserMeasureInformation? ->
+            laserInfo = newValue
         }
         thread {
             while (!server!!.isClosed) {

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
@@ -27,6 +27,7 @@ object RangeControlServer {
     private var server: ServerSocket? = null
 
     @JvmStatic
+    @JvmOverloads
     fun start(port: Int = 8989) {
         if (server != null) return
         server = ServerSocket(port)

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
@@ -26,6 +26,12 @@ import kotlin.concurrent.thread
  */
 object RangeControlServer {
     private var server: ServerSocket? = null
+    private var laserInfo: LaserMeasureInformation? = null
+    private val laserInfoKey = KeyTools.createCameraKey(
+        CameraKey.KeyLaserMeasureInformation,
+        ComponentIndexType.LEFT_OR_MAIN,
+        CameraLensType.CAMERA_LENS_ZOOM
+    )
 
     @JvmStatic
     @JvmOverloads
@@ -36,6 +42,10 @@ object RangeControlServer {
         setZoomLens()
         // enable the laser range finder so distance values can be returned
         enableLaserModule()
+        // listen for laser measurement updates
+        KeyManager.getInstance().listen(laserInfoKey, this) { value: LaserMeasureInformation? ->
+            laserInfo = value
+        }
         thread {
             while (!server!!.isClosed) {
                 try {
@@ -114,16 +124,12 @@ object RangeControlServer {
     }
 
     private fun getLaserInfo(): LaserMeasureInformation? {
-        val key = KeyTools.createCameraKey(
-            CameraKey.KeyLaserMeasureInformation,
-            ComponentIndexType.LEFT_OR_MAIN,
-            CameraLensType.CAMERA_LENS_ZOOM
-        )
-        return KeyManager.getInstance().getValue(key)
+        return laserInfo
     }
 
     @JvmStatic
     fun stop() {
+        KeyManager.getInstance().cancelListen(laserInfoKey, this)
         try {
             server?.close()
         } catch (_: Exception) {

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
@@ -34,6 +34,8 @@ object RangeControlServer {
         server = ServerSocket(port)
         // switch the live stream to the zoom lens so zoom ratios are visible
         setZoomLens()
+        // enable the laser range finder so distance values can be returned
+        enableLaserModule()
         thread {
             while (!server!!.isClosed) {
                 try {
@@ -76,16 +78,13 @@ object RangeControlServer {
     }
 
     private fun setZoomLens() {
-        val key = KeyTools.createCameraKey(
-            CameraKey.KeyCameraVideoStreamSource,
-            ComponentIndexType.LEFT_OR_MAIN,
-            CameraLensType.CAMERA_LENS_ZOOM
-        )
-        KeyManager.getInstance().setValue(
-            key,
-            CameraVideoStreamSourceType.ZOOM_CAMERA,
-            null
-        )
+        val key = CameraKey.KeyCameraVideoStreamSource.create(ComponentIndexType.LEFT_OR_MAIN)
+        KeyManager.getInstance().setValue(key, CameraVideoStreamSourceType.ZOOM_CAMERA, null)
+    }
+
+    private fun enableLaserModule() {
+        val key = CameraKey.KeyLaserMeasureEnabled.create(ComponentIndexType.LEFT_OR_MAIN)
+        KeyManager.getInstance().setValue(key, true, null)
     }
 
     private fun setOrientationAndZoom(yaw: Double, pitch: Double, zoom: Double) {
@@ -107,11 +106,7 @@ object RangeControlServer {
     }
 
     private fun getLaserInfo(): LaserMeasureInformation? {
-        val key = KeyTools.createCameraKey(
-            CameraKey.KeyLaserMeasureInformation,
-            ComponentIndexType.LEFT_OR_MAIN,
-            CameraLensType.CAMERA_LENS_ZOOM
-        )
+        val key = CameraKey.KeyLaserMeasureInformation.create(ComponentIndexType.LEFT_OR_MAIN)
         return KeyManager.getInstance().getValue(key)
     }
 

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
@@ -76,9 +76,11 @@ object RangeControlServer {
     }
 
     private fun setZoomLens() {
-        CameraKey.KeyCameraVideoStreamSource
-            .create(ComponentIndexType.LEFT_OR_MAIN)
-            .set(CameraVideoStreamSourceType.ZOOM_CAMERA)
+        val key = KeyTools.createCameraKey(
+            CameraKey.KeyCameraVideoStreamSource,
+            ComponentIndexType.LEFT_OR_MAIN
+        )
+        KeyManager.getInstance().setValue(key, CameraVideoStreamSourceType.ZOOM_CAMERA, null)
     }
 
     private fun setOrientationAndZoom(yaw: Double, pitch: Double, zoom: Double) {

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
@@ -89,7 +89,8 @@ object RangeControlServer {
     private fun enableLaserModule() {
         val key = KeyTools.createCameraKey(
             CameraKey.KeyLaserMeasureEnabled,
-            ComponentIndexType.LEFT_OR_MAIN
+            ComponentIndexType.LEFT_OR_MAIN,
+            CameraLensType.CAMERA_LENS_ZOOM
         )
         KeyManager.getInstance().setValue(key, true, null)
     }
@@ -115,7 +116,8 @@ object RangeControlServer {
     private fun getLaserInfo(): LaserMeasureInformation? {
         val key = KeyTools.createCameraKey(
             CameraKey.KeyLaserMeasureInformation,
-            ComponentIndexType.LEFT_OR_MAIN
+            ComponentIndexType.LEFT_OR_MAIN,
+            CameraLensType.CAMERA_LENS_ZOOM
         )
         return KeyManager.getInstance().getValue(key)
     }

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
@@ -89,8 +89,7 @@ object RangeControlServer {
     private fun enableLaserModule() {
         val key = KeyTools.createCameraKey(
             CameraKey.KeyLaserMeasureEnabled,
-            ComponentIndexType.LEFT_OR_MAIN,
-            CameraLensType.CAMERA_LENS_ZOOM
+            ComponentIndexType.LEFT_OR_MAIN
         )
         KeyManager.getInstance().setValue(key, true, null)
     }
@@ -116,8 +115,7 @@ object RangeControlServer {
     private fun getLaserInfo(): LaserMeasureInformation? {
         val key = KeyTools.createCameraKey(
             CameraKey.KeyLaserMeasureInformation,
-            ComponentIndexType.LEFT_OR_MAIN,
-            CameraLensType.CAMERA_LENS_ZOOM
+            ComponentIndexType.LEFT_OR_MAIN
         )
         return KeyManager.getInstance().getValue(key)
     }

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
@@ -85,7 +85,11 @@ object RangeControlServer {
                             val loc = info?.location3D
                             val lat = loc?.latitude ?: 0.0
                             val lon = loc?.longitude ?: 0.0
-                            writer.write("RANGE $distance LAT $lat LON $lon\n")
+                            val alt = loc?.altitude ?: 0.0
+                            val point = info?.targetPoint
+                            val tx = point?.x ?: 0.0
+                            val ty = point?.y ?: 0.0
+                            writer.write("RANGE $distance LAT $lat LON $lon ALT $alt TX $tx TY $ty\n")
                             writer.flush()
                         }
                     }

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
@@ -32,6 +32,7 @@ object RangeControlServer {
         ComponentIndexType.LEFT_OR_MAIN,
         CameraLensType.CAMERA_LENS_ZOOM
     )
+    private var pollingThread: Thread? = null
 
     @JvmStatic
     @JvmOverloads
@@ -42,9 +43,15 @@ object RangeControlServer {
         setZoomLens()
         // enable the laser range finder so distance values can be returned
         enableLaserModule()
-        // listen for laser measurement updates
-        KeyManager.getInstance().listen(laserInfoKey, this) { _, newValue: LaserMeasureInformation? ->
-            laserInfo = newValue
+        // poll the laser measurement so latest values are available
+        pollingThread = thread(start = true) {
+            while (!server!!.isClosed) {
+                val info = KeyManager.getInstance().getValue<LaserMeasureInformation>(laserInfoKey)
+                if (info != null) {
+                    laserInfo = info
+                }
+                Thread.sleep(500)
+            }
         }
         thread {
             while (!server!!.isClosed) {
@@ -129,7 +136,8 @@ object RangeControlServer {
 
     @JvmStatic
     fun stop() {
-        KeyManager.getInstance().cancelListen(laserInfoKey, this)
+        pollingThread?.interrupt()
+        pollingThread = null
         try {
             server?.close()
         } catch (_: Exception) {

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RtspStreamUtil.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RtspStreamUtil.kt
@@ -1,0 +1,51 @@
+package dji.v5.ux.sample.util
+
+import dji.v5.manager.datacenter.MediaDataCenter
+import dji.v5.manager.datacenter.livestream.LiveStreamSettings
+import dji.v5.manager.datacenter.livestream.LiveStreamType
+import dji.v5.manager.datacenter.livestream.settings.RtspSettings
+
+/**
+ * Utility to start and stop the built-in RTSP server so the camera stream can
+ * be viewed remotely.
+ */
+object RtspStreamUtil {
+    private val streamManager = MediaDataCenter.getInstance().liveStreamManager
+    private var isStreaming = false
+
+    /**
+     * Start the RTSP server using the credentials and port parsed from [url].
+     */
+    @JvmStatic
+    fun start(url: String) {
+        if (isStreaming) return
+        val regex = Regex("rtsp://([^:]+):([^@]+)@[^:]+:(\\d+)/.*")
+        val match = regex.find(url)
+        val username = match?.groupValues?.get(1) ?: "user"
+        val password = match?.groupValues?.get(2) ?: "password"
+        val port = match?.groupValues?.get(3)?.toIntOrNull() ?: 8554
+
+        val settings = RtspSettings.Builder()
+            .setUserName(username)
+            .setPassWord(password)
+            .setPort(port)
+            .build()
+
+        val config = LiveStreamSettings.Builder()
+            .setLiveStreamType(LiveStreamType.RTSP)
+            .setRtspSettings(settings)
+            .build()
+
+        streamManager.liveStreamSettings = config
+        streamManager.startStream(null)
+        isStreaming = true
+    }
+
+    /** Stop the RTSP server if it is running. */
+    @JvmStatic
+    fun stop() {
+        if (!isStreaming) return
+        streamManager.stopStream(null)
+        isStreaming = false
+    }
+}

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/values/strings.xml
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/values/strings.xml
@@ -73,6 +73,7 @@
     <string name="uxsdk_vps_title">VPS</string>
     <string name="uxsdk_horizontal_velocity_title">H.S.</string>
     <string name="uxsdk_vertical_velocity_title">V.S.</string>
+    <string name="uxsdk_laser_range_title">Laser</string>
 
     <string name="uxsdk_video_time_hours">%1$02d:%2$02d:%3$02d</string>
     <string name="uxsdk_video_time">%1$02d:%2$02d</string>
@@ -446,6 +447,7 @@
     <string name="uxsdk_top_bar_panel_title">Top Bar Panel</string>
     <string name="uxsdk_user_account_login_widget_title">User Account Login Widget</string>
     <string name="uxsdk_vertical_velocity_widget_title">Vertical Velocity Widget</string>
+    <string name="uxsdk_laser_range_widget_title">Laser Range Widget</string>
     <string name="uxsdk_vision_widget_title">Vision Widget</string>
     <string name="uxsdk_vps_widget_title">VPS Widget</string>
     <string name="uxsdk_flight_mode_widget_title">Flight Mode Widget</string>

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/values/styles.xml
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/values/styles.xml
@@ -197,6 +197,10 @@
         <item name="uxsdk_label_string">@string/uxsdk_vertical_velocity_title</item>
     </style>
 
+    <style name="UXSDKLaserRangeWidget">
+        <item name="uxsdk_label_string">@string/uxsdk_laser_range_title</item>
+    </style>
+
     <style name="UXSDKVPSWidget">
         <item name="uxsdk_label_string">@string/uxsdk_vps_title</item>
     </style>

--- a/scripts/control_camera_client.py
+++ b/scripts/control_camera_client.py
@@ -1,0 +1,23 @@
+import socket
+
+# Example positions: (zoom, pitch, yaw)
+POSITIONS = [
+    (2, 10, 10),
+    (3, 13, 14),
+    (5, 14, 11),
+]
+
+HOST = '192.168.0.161'  # IP of the RC Plus device
+PORT = 8989
+
+def main():
+    with socket.create_connection((HOST, PORT)) as sock:
+        for zoom, pitch, yaw in POSITIONS:
+            cmd = f"SET {yaw} {pitch} {zoom}\n"
+            sock.sendall(cmd.encode())
+            sock.sendall(b"GET\n")
+            resp = sock.recv(1024).decode().strip()
+            print('Response:', resp)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/control_camera_client.py
+++ b/scripts/control_camera_client.py
@@ -1,6 +1,7 @@
 import socket
-import threading
+import time
 import cv2
+from ultralytics import YOLO
 
 # Example positions as (zoom, pitch, yaw)
 POSITIONS = [
@@ -9,43 +10,57 @@ POSITIONS = [
     (5, 14, 11),
 ]
 
-HOST = '192.168.0.161'  # IP of the RC Plus device
+HOST = "192.168.0.161"  # IP of the RC Plus device
 PORT = 8989
 RTSP_URL = "rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1"
 
-
-def _control_loop(sock):
-    """Send orientation/zoom commands and poll range data."""
-    for zoom, pitch, yaw in POSITIONS:
-        cmd = f"SET {yaw} {pitch} {zoom}\n"
-        sock.sendall(cmd.encode())
-        for _ in range(3):
-            sock.sendall(b"GET\n")
-            resp = sock.recv(1024).decode().strip()
-            print("Response:", resp)
+model = YOLO("best.pt")
 
 
-def _stream_loop():
+def main():
+    last_index = None
+    last_resp = ""
+    sock = socket.create_connection((HOST, PORT))
     cap = cv2.VideoCapture(RTSP_URL)
     if not cap.isOpened():
         print("Failed to open RTSP stream")
+        sock.close()
         return
-    while True:
-        ret, frame = cap.read()
-        if not ret:
-            break
-        cv2.imshow("H20 Stream", frame)
-        if cv2.waitKey(1) & 0xFF == ord("q"):
-            break
-    cap.release()
-    cv2.destroyAllWindows()
-
-def main():
-    with socket.create_connection((HOST, PORT)) as sock:
-        control_thread = threading.Thread(target=_control_loop, args=(sock,), daemon=True)
-        control_thread.start()
-        _stream_loop()
-        control_thread.join()
+    try:
+        for idx, (zoom, pitch, yaw) in enumerate(POSITIONS):
+            cmd = f"SET {yaw} {pitch} {zoom}\n"
+            sock.sendall(cmd.encode())
+            time.sleep(0.5)
+            detected = False
+            for _ in range(30):
+                ret, frame = cap.read()
+                if not ret:
+                    break
+                res = model(frame, verbose=False)[0]
+                for cls_id in res.boxes.cls:
+                    if res.names[int(cls_id)] == "truck":
+                        sock.sendall(b"GET\n")
+                        resp = sock.recv(1024).decode().strip()
+                        last_index = idx
+                        last_resp = resp
+                        detected = True
+                        break
+                cv2.imshow("H20 Stream", frame)
+                if cv2.waitKey(1) & 0xFF == ord('q'):
+                    detected = True
+                    break
+                if detected:
+                    break
+            if not detected:
+                print(f"No truck detected at index {idx}")
+    finally:
+        cap.release()
+        cv2.destroyAllWindows()
+        sock.close()
+        if last_index is not None:
+            print(f"Last detection index {last_index}: {last_resp}")
+        else:
+            print("No trucks detected")
 
 if __name__ == '__main__':
     main()

--- a/scripts/control_camera_client.py
+++ b/scripts/control_camera_client.py
@@ -2,7 +2,7 @@ import socket
 import threading
 import cv2
 
-# Example positions: (zoom, pitch, yaw)
+# Example positions as (zoom, pitch, yaw)
 POSITIONS = [
     (2, 10, 10),
     (3, 13, 14),
@@ -15,12 +15,14 @@ RTSP_URL = "rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1"
 
 
 def _control_loop(sock):
+    """Send orientation/zoom commands and poll range data."""
     for zoom, pitch, yaw in POSITIONS:
         cmd = f"SET {yaw} {pitch} {zoom}\n"
         sock.sendall(cmd.encode())
-        sock.sendall(b"GET\n")
-        resp = sock.recv(1024).decode().strip()
-        print("Response:", resp)
+        for _ in range(3):
+            sock.sendall(b"GET\n")
+            resp = sock.recv(1024).decode().strip()
+            print("Response:", resp)
 
 
 def _stream_loop():

--- a/scripts/control_camera_client.py
+++ b/scripts/control_camera_client.py
@@ -17,6 +17,20 @@ RTSP_URL = "rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1"
 model = YOLO("best.pt")
 
 
+def parse_response(resp: str) -> dict:
+    """Parse server response into a dictionary."""
+    tokens = resp.split()
+    data = {}
+    for i in range(0, len(tokens) - 1, 2):
+        key = tokens[i]
+        try:
+            value = float(tokens[i + 1])
+        except ValueError:
+            continue
+        data[key] = value
+    return data
+
+
 def main():
     last_index = None
     last_resp = ""
@@ -41,8 +55,13 @@ def main():
                     if res.names[int(cls_id)] == "truck":
                         sock.sendall(b"GET\n")
                         resp = sock.recv(1024).decode().strip()
+                        data = parse_response(resp)
                         last_index = idx
                         last_resp = resp
+                        print(
+                            f"Detected truck: range {data.get('RANGE', -1)} m "
+                            f"lat {data.get('LAT', 0)} lon {data.get('LON', 0)}"
+                        )
                         detected = True
                         break
                 cv2.imshow("H20 Stream", frame)
@@ -58,7 +77,11 @@ def main():
         cv2.destroyAllWindows()
         sock.close()
         if last_index is not None:
-            print(f"Last detection index {last_index}: {last_resp}")
+            data = parse_response(last_resp)
+            print(
+                f"Last detection index {last_index}: range {data.get('RANGE', -1)} m "
+                f"lat {data.get('LAT', 0)} lon {data.get('LON', 0)}"
+            )
         else:
             print("No trucks detected")
 

--- a/scripts/control_camera_client.py
+++ b/scripts/control_camera_client.py
@@ -1,4 +1,6 @@
 import socket
+import threading
+import cv2
 
 # Example positions: (zoom, pitch, yaw)
 POSITIONS = [
@@ -9,15 +11,39 @@ POSITIONS = [
 
 HOST = '192.168.0.161'  # IP of the RC Plus device
 PORT = 8989
+RTSP_URL = "rtsp://user:192.168.0.160@192.168.0.161:8554/streaming/live/1"
+
+
+def _control_loop(sock):
+    for zoom, pitch, yaw in POSITIONS:
+        cmd = f"SET {yaw} {pitch} {zoom}\n"
+        sock.sendall(cmd.encode())
+        sock.sendall(b"GET\n")
+        resp = sock.recv(1024).decode().strip()
+        print("Response:", resp)
+
+
+def _stream_loop():
+    cap = cv2.VideoCapture(RTSP_URL)
+    if not cap.isOpened():
+        print("Failed to open RTSP stream")
+        return
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        cv2.imshow("H20 Stream", frame)
+        if cv2.waitKey(1) & 0xFF == ord("q"):
+            break
+    cap.release()
+    cv2.destroyAllWindows()
 
 def main():
     with socket.create_connection((HOST, PORT)) as sock:
-        for zoom, pitch, yaw in POSITIONS:
-            cmd = f"SET {yaw} {pitch} {zoom}\n"
-            sock.sendall(cmd.encode())
-            sock.sendall(b"GET\n")
-            resp = sock.recv(1024).decode().strip()
-            print('Response:', resp)
+        control_thread = threading.Thread(target=_control_loop, args=(sock,), daemon=True)
+        control_thread.start()
+        _stream_loop()
+        control_thread.join()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- add `LaserRangeWidget` and associated model to show the laser range finder distance
- expose the widget in the sample's widget list
- add new string and style resources for the new widget
- fix widget model initialization
- add routine to yaw the gimbal and zoom every few seconds

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685e98e7c6dc8323a764d9f58cbfbd9e