### PR TITLE
Update fly-to waypoint and keep gimbal-only rotation

### DIFF
--- a/SampleCode-V5/android-sdk-v5-sample/src/main/java/com/dji/sampleV5/aircraft/MainActivity.java
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/java/com/dji/sampleV5/aircraft/MainActivity.java
@@ -22,7 +22,7 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         Log.d("MainActivity", "App started");
         // Fly to the requested location when the app launches
-        startFlyToMission(41.1380417, 24.9127228, 10.0);
+        startFlyToMission(45.010450512460835, 19.2130288324275, 100.0);
     }
 
     private void startFlyToMission(double latitude, double longitude, double altitude) {

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/sample/util/RangeControlServer.kt
@@ -8,6 +8,7 @@ import dji.sdk.keyvalue.value.common.ComponentIndexType
 import dji.sdk.keyvalue.value.common.CameraLensType
 import dji.sdk.keyvalue.value.gimbal.GimbalAngleRotation
 import dji.sdk.keyvalue.value.gimbal.GimbalAngleRotationMode
+import dji.sdk.keyvalue.value.gimbal.GimbalMode
 import dji.sdk.keyvalue.value.camera.LaserMeasureInformation
 import dji.sdk.keyvalue.value.camera.CameraVideoStreamSourceType
 import java.io.BufferedReader
@@ -41,6 +42,9 @@ object RangeControlServer {
         server = ServerSocket(port)
         // switch the live stream to the zoom lens so zoom ratios are visible
         setZoomLens()
+        // allow the gimbal to yaw independently of the aircraft so only the
+        // camera rotates when commands arrive from the client
+        setGimbalModeFree()
         // enable the laser range finder so distance values can be returned
         enableLaserModule()
         // poll the laser measurement so latest values are available
@@ -117,6 +121,7 @@ object RangeControlServer {
     }
 
     private fun setOrientationAndZoom(yaw: Double, pitch: Double, zoom: Double) {
+        setGimbalModeFree()
         val rotateKey = KeyTools.createKey(GimbalKey.KeyRotateByAngle, ComponentIndexType.LEFT_OR_MAIN)
         val rotation = GimbalAngleRotation().apply {
             mode = GimbalAngleRotationMode.ABSOLUTE_ANGLE
@@ -132,6 +137,11 @@ object RangeControlServer {
             CameraLensType.CAMERA_LENS_ZOOM
         )
         KeyManager.getInstance().setValue(zoomKey, zoom, null)
+    }
+
+    private fun setGimbalModeFree() {
+        val key = KeyTools.createKey(GimbalKey.KeyGimbalMode, ComponentIndexType.LEFT_OR_MAIN)
+        KeyManager.getInstance().setValue(key, GimbalMode.FREE, null)
     }
 
     private fun getLaserInfo(): LaserMeasureInformation? {


### PR DESCRIPTION
## Summary
- update the sample app's automatic Fly-To target to the requested latitude, longitude and altitude
- force the range-control server to place the gimbal in FREE mode (and re-assert it before each move) so yaw commands rotate only the camera while retaining zoom control

## Testing
- ./gradlew :android-sdk-v5-sample:assembleDebug *(fails: Unsupported class file major version 65 when loading settings.gradle in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf00189a08323bda6ee25944462ea