### PR TITLE
Add DEM-based georegistration pipeline library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,10 @@ fastlane/readme.md
 # Version control
 vcs.xml
 
+# Python artifacts
+__pycache__/
+*.pyc
+
 # lint
 lint/intermediates/
 lint/generated/

--- a/georeg/__init__.py
+++ b/georeg/__init__.py
@@ -1,0 +1,28 @@
+"""DEM-based georegistration pipeline."""
+
+from .camera_model import CameraModel
+from .config import Config, DEMConfig, DEMProviderConfig, CameraConfig, GeoidConfig, RuntimeConfig, load_config
+from .corridor import CorridorBuilder
+from .dem_manager import DEMManager
+from .geo_projector import GeoProjector
+from .geoid import GeoidModel
+from .models import DetectionResult, Intrinsics, Pose, Provenance
+
+__all__ = [
+    "CameraModel",
+    "Config",
+    "DEMConfig",
+    "DEMProviderConfig",
+    "CameraConfig",
+    "GeoidConfig",
+    "RuntimeConfig",
+    "load_config",
+    "CorridorBuilder",
+    "DEMManager",
+    "GeoProjector",
+    "GeoidModel",
+    "DetectionResult",
+    "Intrinsics",
+    "Pose",
+    "Provenance",
+]

--- a/georeg/__init__.py
+++ b/georeg/__init__.py
@@ -1,16 +1,27 @@
 """DEM-based georegistration pipeline."""
 
 from .camera_model import CameraModel
-from .config import Config, DEMConfig, DEMProviderConfig, CameraConfig, GeoidConfig, RuntimeConfig, load_config
+from .config import (
+    CameraConfig,
+    Config,
+    DEMCacheConfig,
+    DEMConfig,
+    DEMProviderConfig,
+    GeoidConfig,
+    RuntimeConfig,
+    load_config,
+)
 from .corridor import CorridorBuilder
 from .dem_manager import DEMManager
 from .geo_projector import GeoProjector
 from .geoid import GeoidModel
 from .models import DetectionResult, Intrinsics, Pose, Provenance
+from .pipeline import GeoregistrationPipeline
 
 __all__ = [
     "CameraModel",
     "Config",
+    "DEMCacheConfig",
     "DEMConfig",
     "DEMProviderConfig",
     "CameraConfig",
@@ -25,4 +36,5 @@ __all__ = [
     "Intrinsics",
     "Pose",
     "Provenance",
+    "GeoregistrationPipeline",
 ]

--- a/georeg/camera_model.py
+++ b/georeg/camera_model.py
@@ -1,0 +1,73 @@
+"""Camera model utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+import json
+import numpy as np
+
+from .models import Intrinsics, hash_intrinsics_profile
+
+
+@dataclass(slots=True)
+class CameraModel:
+    """Interpolates intrinsics from a calibration lookup table."""
+
+    lut_json_path: Path
+
+    def __post_init__(self) -> None:
+        with open(self.lut_json_path, "r", encoding="utf-8") as handle:
+            raw = json.load(handle)
+        self._profiles = {
+            float(key): Intrinsics(
+                zoom=float(key),
+                K=np.asarray(value["K"], dtype=float),
+                distortion=value.get("dist"),
+                image_size=tuple(value.get("image_size", ())) or None,
+            )
+            for key, value in raw.items()
+        }
+        if not self._profiles:
+            raise ValueError("The intrinsics LUT cannot be empty")
+        self._sorted_zoom = sorted(self._profiles)
+        self.profile_hash = hash_intrinsics_profile(sorted(raw.items()))
+
+    def _interpolate(self, zoom: float) -> Intrinsics:
+        if zoom in self._profiles:
+            return self._profiles[zoom]
+        # clamp to bounds
+        if zoom <= self._sorted_zoom[0]:
+            return self._profiles[self._sorted_zoom[0]]
+        if zoom >= self._sorted_zoom[-1]:
+            return self._profiles[self._sorted_zoom[-1]]
+
+        for low, high in zip(self._sorted_zoom[:-1], self._sorted_zoom[1:]):
+            if low <= zoom <= high:
+                alpha = (zoom - low) / (high - low)
+                K_low = self._profiles[low].K
+                K_high = self._profiles[high].K
+                K_interp = (1 - alpha) * K_low + alpha * K_high
+                return Intrinsics(zoom=zoom, K=K_interp)
+        raise RuntimeError("Interpolation failed for zoom level")
+
+    def K_for_zoom(self, zoom: float) -> np.ndarray:
+        """Return the 3x3 intrinsic matrix for a zoom level."""
+
+        return self._interpolate(zoom).K
+
+    def dir_cam(self, u: float, v: float, K: np.ndarray) -> np.ndarray:
+        """Compute the unit ray in camera coordinates for an image point."""
+
+        fx, fy = K[0, 0], K[1, 1]
+        cx, cy = K[0, 2], K[1, 2]
+        x = (u - cx) / fx
+        y = (v - cy) / fy
+        ray = np.array([x, y, 1.0], dtype=float)
+        return ray / np.linalg.norm(ray)
+
+    def intrinsics_hash(self) -> str:
+        """Return the provenance hash of the LUT file."""
+
+        return self.profile_hash

--- a/georeg/config.py
+++ b/georeg/config.py
@@ -1,0 +1,104 @@
+"""Configuration helpers for the georegistration pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+import yaml
+
+
+@dataclass(slots=True)
+class DEMProviderConfig:
+    name: str
+    stac_url: str
+    collection: str
+
+
+@dataclass(slots=True)
+class DEMConfig:
+    providers: Sequence[DEMProviderConfig]
+    cache_dir: Path
+    max_cache_gb: float = 10.0
+    buffer_m: float = 2000.0
+
+
+@dataclass(slots=True)
+class CameraConfig:
+    lut_json: Path
+
+
+@dataclass(slots=True)
+class GeoidConfig:
+    model: str = "EGM2008"
+    grid_path: Optional[Path] = None
+
+
+@dataclass(slots=True)
+class RuntimeConfig:
+    eps_m: float = 0.05
+    max_iters: int = 2
+    use_lrf: bool = True
+
+
+@dataclass(slots=True)
+class Config:
+    dem: DEMConfig
+    camera: CameraConfig
+    geoid: GeoidConfig = field(default_factory=GeoidConfig)
+    runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
+
+
+def _coerce_providers(raw: Iterable[Dict[str, Any]]) -> List[DEMProviderConfig]:
+    providers: List[DEMProviderConfig] = []
+    for entry in raw:
+        providers.append(
+            DEMProviderConfig(
+                name=str(entry["name"]),
+                stac_url=str(entry["stac_url"]),
+                collection=str(entry["collection"]),
+            )
+        )
+    return providers
+
+
+def load_config(path: str | Path) -> Config:
+    """Load the YAML configuration file."""
+
+    with open(path, "r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+
+    dem = data.get("dem", {})
+    providers = _coerce_providers(dem.get("providers", []))
+    if not providers:
+        raise ValueError("At least one DEM provider must be configured")
+
+    dem_cfg = DEMConfig(
+        providers=providers,
+        cache_dir=Path(dem["cache_dir"]),
+        max_cache_gb=float(dem.get("max_cache_gb", 10.0)),
+        buffer_m=float(dem.get("buffer_m", 2000.0)),
+    )
+
+    cam = data.get("camera", {})
+    camera_cfg = CameraConfig(lut_json=Path(cam["lut_json"]))
+
+    geoid_data = data.get("geoid", {})
+    geoid_cfg = GeoidConfig(
+        model=str(geoid_data.get("model", "EGM2008")),
+        grid_path=(Path(geoid_data["grid_path"]) if geoid_data.get("grid_path") else None),
+    )
+
+    runtime_data = data.get("runtime", {})
+    runtime_cfg = RuntimeConfig(
+        eps_m=float(runtime_data.get("eps_m", 0.05)),
+        max_iters=int(runtime_data.get("max_iters", 2)),
+        use_lrf=bool(runtime_data.get("use_lrf", True)),
+    )
+
+    return Config(
+        dem=dem_cfg,
+        camera=camera_cfg,
+        geoid=geoid_cfg,
+        runtime=runtime_cfg,
+    )

--- a/georeg/config.py
+++ b/georeg/config.py
@@ -3,24 +3,83 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
 
 import yaml
 
 
 @dataclass(slots=True)
 class DEMProviderConfig:
+    """Configuration for a single DEM provider."""
+
     name: str
-    stac_url: str
-    collection: str
+    data_type: str = "COG"
+    root: Optional[str] = None
+    stac_url: Optional[str] = None
+    collection: Optional[str] = None
+    tile_template: Optional[str] = None
+    resolution_arcsec: Optional[float] = None
+    nodata: Optional[float] = None
+    note: Optional[str] = None
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "DEMProviderConfig":
+        return cls(
+            name=str(data["name"]),
+            data_type=str(data.get("type", data.get("data_type", "COG"))),
+            root=data.get("root"),
+            stac_url=data.get("stac") or data.get("stac_url"),
+            collection=data.get("collection"),
+            tile_template=data.get("tile_template"),
+            resolution_arcsec=(
+                float(data["resolution_arcsec"]) if data.get("resolution_arcsec") is not None else None
+            ),
+            nodata=(float(data["nodata"]) if data.get("nodata") is not None else None),
+            note=data.get("note"),
+        )
+
+
+@dataclass(slots=True)
+class DEMCacheConfig:
+    """Settings describing how DEM assets are cached locally."""
+
+    directory: Path
+    max_bytes: int
+    index_file: str = "cache_index.json"
+    prefer_full_tile_download: bool = True
+    http_timeout_sec: float = 30.0
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "DEMCacheConfig":
+        directory = Path(data.get("dir") or data.get("directory"))
+        max_bytes_raw = data.get("max_bytes")
+        if max_bytes_raw is None and data.get("max_cache_gb") is not None:
+            max_bytes_raw = float(data["max_cache_gb"]) * (1024**3)
+        if max_bytes_raw is None:
+            raise ValueError("DEM cache configuration requires 'max_bytes' or 'max_cache_gb'")
+        return cls(
+            directory=directory,
+            max_bytes=int(max_bytes_raw),
+            index_file=str(data.get("index_file", "cache_index.json")),
+            prefer_full_tile_download=bool(data.get("prefer_full_tile_download", True)),
+            http_timeout_sec=float(data.get("http_timeout_sec", 30.0)),
+        )
 
 
 @dataclass(slots=True)
 class DEMConfig:
-    providers: Sequence[DEMProviderConfig]
-    cache_dir: Path
-    max_cache_gb: float = 10.0
+    """Full DEM configuration including providers and cache."""
+
+    primary: DEMProviderConfig
+    fallbacks: Sequence[DEMProviderConfig] = field(default_factory=tuple)
+    cache: DEMCacheConfig = field(
+        default_factory=lambda: DEMCacheConfig(directory=Path("./dem_cache"), max_bytes=int(5 * 1024**3))
+    )
     buffer_m: float = 2000.0
+
+    @property
+    def providers(self) -> Sequence[DEMProviderConfig]:
+        return (self.primary,) + tuple(self.fallbacks)
 
 
 @dataclass(slots=True)
@@ -32,6 +91,8 @@ class CameraConfig:
 class GeoidConfig:
     model: str = "EGM2008"
     grid_path: Optional[Path] = None
+    height_type_in_dem: str = "orthometric"
+    height_type_from_gnss: str = "ellipsoidal"
 
 
 @dataclass(slots=True)
@@ -39,6 +100,7 @@ class RuntimeConfig:
     eps_m: float = 0.05
     max_iters: int = 2
     use_lrf: bool = True
+    dem_variance: float = 1.0
 
 
 @dataclass(slots=True)
@@ -49,17 +111,55 @@ class Config:
     runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
 
 
-def _coerce_providers(raw: Iterable[Dict[str, Any]]) -> List[DEMProviderConfig]:
-    providers: List[DEMProviderConfig] = []
-    for entry in raw:
-        providers.append(
-            DEMProviderConfig(
-                name=str(entry["name"]),
-                stac_url=str(entry["stac_url"]),
-                collection=str(entry["collection"]),
-            )
+def _coerce_provider_list(raw: Iterable[Mapping[str, Any]]) -> List[DEMProviderConfig]:
+    return [DEMProviderConfig.from_mapping(entry) for entry in raw]
+
+
+def _load_dem_config(dem_section: Mapping[str, Any]) -> DEMConfig:
+    # Backwards compatible path with legacy 'providers'
+    if "providers" in dem_section:
+        providers = _coerce_provider_list(dem_section.get("providers", []))
+        if not providers:
+            raise ValueError("At least one DEM provider must be configured")
+        cache_dir = Path(dem_section["cache_dir"])
+        max_gb = float(dem_section.get("max_cache_gb", 10.0))
+        cache = DEMCacheConfig(
+            directory=cache_dir,
+            max_bytes=int(max_gb * (1024**3)),
+            index_file=str(dem_section.get("index_file", "cache_index.json")),
+            prefer_full_tile_download=True,
+            http_timeout_sec=float(dem_section.get("http_timeout_sec", 30.0)),
         )
-    return providers
+        return DEMConfig(
+            primary=providers[0],
+            fallbacks=providers[1:],
+            cache=cache,
+            buffer_m=float(dem_section.get("buffer_m", 2000.0)),
+        )
+
+    if "primary" not in dem_section:
+        raise ValueError("DEM configuration must include a 'primary' provider")
+
+    primary = DEMProviderConfig.from_mapping(dem_section["primary"])
+    fallback_section = dem_section.get("fallback")
+    if isinstance(fallback_section, Mapping):
+        fallbacks = [DEMProviderConfig.from_mapping(fallback_section)]
+    elif isinstance(fallback_section, Iterable) and not isinstance(fallback_section, (str, bytes)):
+        fallbacks = _coerce_provider_list(fallback_section)
+    else:
+        fallbacks = []
+
+    cache_cfg = dem_section.get("cache")
+    if cache_cfg is None:
+        raise ValueError("DEM configuration requires a 'cache' section")
+    cache = DEMCacheConfig.from_mapping(cache_cfg)
+
+    return DEMConfig(
+        primary=primary,
+        fallbacks=fallbacks,
+        cache=cache,
+        buffer_m=float(dem_section.get("buffer_m", dem_section.get("corridor_buffer_m", 2000.0))),
+    )
 
 
 def load_config(path: str | Path) -> Config:
@@ -68,25 +168,19 @@ def load_config(path: str | Path) -> Config:
     with open(path, "r", encoding="utf-8") as handle:
         data = yaml.safe_load(handle)
 
-    dem = data.get("dem", {})
-    providers = _coerce_providers(dem.get("providers", []))
-    if not providers:
-        raise ValueError("At least one DEM provider must be configured")
-
-    dem_cfg = DEMConfig(
-        providers=providers,
-        cache_dir=Path(dem["cache_dir"]),
-        max_cache_gb=float(dem.get("max_cache_gb", 10.0)),
-        buffer_m=float(dem.get("buffer_m", 2000.0)),
-    )
+    dem_cfg = _load_dem_config(data.get("dem", {}))
 
     cam = data.get("camera", {})
+    if "lut_json" not in cam:
+        raise ValueError("Camera configuration requires 'lut_json'")
     camera_cfg = CameraConfig(lut_json=Path(cam["lut_json"]))
 
     geoid_data = data.get("geoid", {})
     geoid_cfg = GeoidConfig(
         model=str(geoid_data.get("model", "EGM2008")),
         grid_path=(Path(geoid_data["grid_path"]) if geoid_data.get("grid_path") else None),
+        height_type_in_dem=str(geoid_data.get("height_type_in_dem", "orthometric")),
+        height_type_from_gnss=str(geoid_data.get("height_type_from_gnss", "ellipsoidal")),
     )
 
     runtime_data = data.get("runtime", {})
@@ -94,6 +188,7 @@ def load_config(path: str | Path) -> Config:
         eps_m=float(runtime_data.get("eps_m", 0.05)),
         max_iters=int(runtime_data.get("max_iters", 2)),
         use_lrf=bool(runtime_data.get("use_lrf", True)),
+        dem_variance=float(runtime_data.get("dem_variance", 1.0)),
     )
 
     return Config(

--- a/georeg/corridor.py
+++ b/georeg/corridor.py
@@ -1,0 +1,52 @@
+"""Mission corridor construction."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence, Tuple
+
+from shapely.geometry import LineString
+from shapely.ops import transform
+import pyproj
+
+from .models import Corridor
+
+
+@dataclass(slots=True)
+class CorridorBuilder:
+    """Build a mission corridor around waypoints."""
+
+    buffer_m: float = 2000.0
+
+    def build_corridor(self, waypoints_wgs84: Sequence[Tuple[float, float]]) -> Corridor:
+        if len(waypoints_wgs84) < 2:
+            raise ValueError("At least two waypoints are required to build a corridor")
+
+        line = LineString([(lon, lat) for lat, lon in waypoints_wgs84])
+
+        # Determine a UTM zone from the centroid
+        centroid = line.centroid
+        utm_crs = self._utm_crs(centroid.y, centroid.x)
+        project_to_utm = pyproj.Transformer.from_crs("EPSG:4326", utm_crs, always_xy=True).transform
+        project_to_wgs = pyproj.Transformer.from_crs(utm_crs, "EPSG:4326", always_xy=True).transform
+
+        corridor_utm = transform(project_to_utm, line).buffer(self.buffer_m)
+        corridor_wgs84 = transform(project_to_wgs, corridor_utm)
+
+        return Corridor(
+            polygon_wgs84=corridor_wgs84,
+            polygon_projected=corridor_utm,
+            projected_crs=utm_crs,
+        )
+
+    @staticmethod
+    def _utm_crs(lat: float, lon: float) -> pyproj.CRS:
+        zone = int((lon + 180) / 6) + 1
+        is_northern = lat >= 0
+        return pyproj.CRS.from_dict(
+            {
+                "proj": "utm",
+                "zone": zone,
+                "datum": "WGS84",
+                "south": not is_northern,
+            }
+        )

--- a/georeg/dem_manager.py
+++ b/georeg/dem_manager.py
@@ -1,0 +1,166 @@
+"""DEM management, discovery and sampling."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import logging
+import math
+import os
+import threading
+
+import cachetools
+import numpy as np
+import rasterio
+from rasterio.windows import Window
+from shapely.geometry import Point, shape
+from pystac_client import Client
+import requests
+
+from .config import DEMConfig, DEMProviderConfig
+from .corridor import CorridorBuilder
+from .models import Corridor, DEMTileRecord
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class DEMManager:
+    """Discover, download and sample DEM tiles."""
+
+    config: DEMConfig
+    _corridor: Optional[Corridor] = field(init=False, default=None)
+    _providers: Sequence[DEMProviderConfig] = field(init=False)
+    _cache_dir: Path = field(init=False)
+    _tile_records: List[DEMTileRecord] = field(init=False, default_factory=list)
+    _dataset_cache: cachetools.LRUCache = field(init=False)
+    _lock: threading.Lock = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._providers = self.config.providers
+        self._cache_dir = Path(self.config.cache_dir)
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        self._tile_records = []
+        self._dataset_cache = cachetools.LRUCache(maxsize=8)
+        self._lock = threading.Lock()
+
+    def build_corridor(self, waypoints_wgs84: Sequence[Tuple[float, float]], buffer_m: float | None = None) -> None:
+        builder = CorridorBuilder(buffer_m=buffer_m or self.config.buffer_m)
+        self._corridor = builder.build_corridor(waypoints_wgs84)
+
+    @property
+    def corridor(self) -> Corridor:
+        if self._corridor is None:
+            raise RuntimeError("Corridor has not been built yet")
+        return self._corridor
+
+    def ensure_tiles(self) -> None:
+        if self._corridor is None:
+            raise RuntimeError("Corridor must be built before fetching tiles")
+
+        for provider in self._providers:
+            try:
+                self._fetch_tiles_from_provider(provider)
+                if self._tile_records:
+                    return
+            except Exception as exc:  # pragma: no cover - defensive logging
+                LOGGER.warning("DEM provider %s failed: %s", provider.name, exc)
+        if not self._tile_records:
+            raise RuntimeError("Failed to acquire DEM tiles from all providers")
+
+    def _fetch_tiles_from_provider(self, provider: DEMProviderConfig) -> None:
+        client = Client.open(provider.stac_url)
+        corridor_geom = self._corridor.polygon_wgs84.__geo_interface__
+        search = client.search(collections=[provider.collection], intersects=corridor_geom)
+        items = list(search.get_items())
+        if not items:
+            raise RuntimeError(f"No DEM tiles found for provider {provider.name}")
+        for item in items:
+            asset = item.assets.get("data") or next(iter(item.assets.values()))
+            href = asset.href
+            path = self._download_cog(href)
+            geom = shape(item.geometry)
+            tile = DEMTileRecord(
+                product=provider.name,
+                identifier=item.id,
+                path=str(path),
+                footprint=geom,
+                resolution=float(item.properties.get("gsd", asset.extra_fields.get("gsd", 30))),
+                nodata=asset.extra_fields.get("nodata"),
+            )
+            self._tile_records.append(tile)
+
+    def _download_cog(self, href: str) -> Path:
+        filename = os.path.basename(href)
+        target = self._cache_dir / filename
+        if target.exists():
+            return target
+
+        LOGGER.info("Downloading DEM tile %s", href)
+        with requests.get(href, stream=True, timeout=30) as response:
+            response.raise_for_status()
+            with open(target, "wb") as handle:
+                for chunk in response.iter_content(chunk_size=1024 * 512):
+                    handle.write(chunk)
+        return target
+
+    def _dataset(self, tile: DEMTileRecord) -> rasterio.io.DatasetReader:
+        with self._lock:
+            ds = self._dataset_cache.get(tile.path)
+            if ds is None:
+                ds = rasterio.open(tile.path)
+                self._dataset_cache[tile.path] = ds
+        return ds
+
+    def sample(self, lat: float, lon: float) -> Tuple[float, Dict[str, object]]:
+        if not self._tile_records:
+            raise RuntimeError("DEM tiles have not been fetched")
+
+        point = Point(lon, lat)
+        for tile in self._tile_records:
+            if tile.footprint.contains(point):
+                height = self._sample_tile(tile, lat, lon)
+                meta = {
+                    "dem_product": tile.product,
+                    "tile_ids": [tile.identifier],
+                }
+                return height, meta
+        raise ValueError("Location outside of DEM coverage")
+
+    def _sample_tile(self, tile: DEMTileRecord, lat: float, lon: float) -> float:
+        dataset = self._dataset(tile)
+        row, col = dataset.index(lon, lat)
+        window = Window(col_off=col - 1, row_off=row - 1, width=2, height=2)
+        window = window.round_offsets().round_lengths()
+        arr = dataset.read(1, window=window, boundless=True, fill_value=dataset.nodata)
+        transform = dataset.window_transform(window)
+        # convert to float, handle nodata
+        nodata = dataset.nodata if dataset.nodata is not None else tile.nodata
+        arr = arr.astype(float)
+        if nodata is not None:
+            arr[arr == nodata] = np.nan
+        x, y = rasterio.transform.rowcol(transform, lon, lat)
+        fx = x - math.floor(x)
+        fy = y - math.floor(y)
+        top = (1 - fx) * arr[0, 0] + fx * arr[0, 1]
+        bottom = (1 - fx) * arr[1, 0] + fx * arr[1, 1]
+        value = (1 - fy) * top + fy * bottom
+        if np.isnan(value):
+            raise ValueError("DEM sample contains NoData")
+        return float(value)
+
+    def initial_height(self) -> float:
+        if not self._tile_records:
+            return 0.0
+        heights = []
+        for tile in self._tile_records[:3]:
+            ds = self._dataset(tile)
+            sample = ds.read(1, window=Window(0, 0, 1, 1))
+            heights.append(float(sample[0, 0]))
+        return float(np.nanmedian(heights)) if heights else 0.0
+
+    def close(self) -> None:
+        for ds in list(self._dataset_cache.values()):
+            ds.close()
+        self._dataset_cache.clear()

--- a/georeg/dem_manager.py
+++ b/georeg/dem_manager.py
@@ -9,6 +9,8 @@ import logging
 import math
 import os
 import threading
+import time
+import json
 
 import cachetools
 import numpy as np
@@ -18,7 +20,7 @@ from shapely.geometry import Point, shape
 from pystac_client import Client
 import requests
 
-from .config import DEMConfig, DEMProviderConfig
+from .config import DEMCacheConfig, DEMConfig, DEMProviderConfig
 from .corridor import CorridorBuilder
 from .models import Corridor, DEMTileRecord
 
@@ -32,15 +34,21 @@ class DEMManager:
     config: DEMConfig
     _corridor: Optional[Corridor] = field(init=False, default=None)
     _providers: Sequence[DEMProviderConfig] = field(init=False)
+    _cache_cfg: DEMCacheConfig = field(init=False)
     _cache_dir: Path = field(init=False)
+    _cache_index_path: Path = field(init=False)
+    _cache_index: Dict[str, Dict[str, float]] = field(init=False)
     _tile_records: List[DEMTileRecord] = field(init=False, default_factory=list)
     _dataset_cache: cachetools.LRUCache = field(init=False)
     _lock: threading.Lock = field(init=False)
 
     def __post_init__(self) -> None:
         self._providers = self.config.providers
-        self._cache_dir = Path(self.config.cache_dir)
+        self._cache_cfg = self.config.cache
+        self._cache_dir = Path(self._cache_cfg.directory)
         self._cache_dir.mkdir(parents=True, exist_ok=True)
+        self._cache_index_path = self._cache_dir / self._cache_cfg.index_file
+        self._cache_index = self._load_cache_index()
         self._tile_records = []
         self._dataset_cache = cachetools.LRUCache(maxsize=8)
         self._lock = threading.Lock()
@@ -70,9 +78,23 @@ class DEMManager:
             raise RuntimeError("Failed to acquire DEM tiles from all providers")
 
     def _fetch_tiles_from_provider(self, provider: DEMProviderConfig) -> None:
+        if provider.stac_url:
+            self._fetch_via_stac(provider)
+        elif provider.tile_template and provider.root:
+            self._fetch_via_template(provider)
+        else:
+            raise RuntimeError(
+                f"Provider {provider.name} does not expose a supported acquisition mechanism"
+            )
+
+    def _fetch_via_stac(self, provider: DEMProviderConfig) -> None:
+        assert self._corridor is not None
         client = Client.open(provider.stac_url)
         corridor_geom = self._corridor.polygon_wgs84.__geo_interface__
-        search = client.search(collections=[provider.collection], intersects=corridor_geom)
+        search_kwargs: Dict[str, object] = {"intersects": corridor_geom}
+        if provider.collection:
+            search_kwargs["collections"] = [provider.collection]
+        search = client.search(**search_kwargs)
         items = list(search.get_items())
         if not items:
             raise RuntimeError(f"No DEM tiles found for provider {provider.name}")
@@ -86,24 +108,113 @@ class DEMManager:
                 identifier=item.id,
                 path=str(path),
                 footprint=geom,
-                resolution=float(item.properties.get("gsd", asset.extra_fields.get("gsd", 30))),
-                nodata=asset.extra_fields.get("nodata"),
+                resolution=float(item.properties.get("gsd", asset.extra_fields.get("gsd", provider.resolution_arcsec or 30))),
+                nodata=asset.extra_fields.get("nodata", provider.nodata),
             )
             self._tile_records.append(tile)
 
+    def _fetch_via_template(self, provider: DEMProviderConfig) -> None:
+        from shapely.geometry import box
+
+        assert self._corridor is not None
+        minx, miny, maxx, maxy = self._corridor.polygon_wgs84.bounds
+        lat_start = math.floor(miny)
+        lat_end = math.ceil(maxy)
+        lon_start = math.floor(minx)
+        lon_end = math.ceil(maxx)
+        for lat_deg in range(lat_start, lat_end):
+            for lon_deg in range(lon_start, lon_end):
+                href, identifier = self._template_href(provider, lat_deg, lon_deg)
+                path = self._download_cog(href)
+                geom = box(lon_deg, lat_deg, lon_deg + 1, lat_deg + 1)
+                tile = DEMTileRecord(
+                    product=provider.name,
+                    identifier=identifier,
+                    path=str(path),
+                    footprint=geom,
+                    resolution=float(provider.resolution_arcsec or 1.0) * 30.0,
+                    nodata=provider.nodata,
+                )
+                self._tile_records.append(tile)
+
+    def _template_href(self, provider: DEMProviderConfig, lat_deg: int, lon_deg: int) -> Tuple[str, str]:
+        if not provider.tile_template:
+            raise RuntimeError("Tile template missing for template-based provider")
+        lat_band = "N" if lat_deg >= 0 else "S"
+        lon_band = "E" if lon_deg >= 0 else "W"
+        lat_fmt = f"{abs(int(lat_deg)):02d}"
+        lon_fmt = f"{abs(int(lon_deg)):03d}"
+        identifier = provider.tile_template.format(NS=lat_band, EW=lon_band, LAT=lat_fmt, LON=lon_fmt)
+        root = provider.root or ""
+        if root and not root.endswith("/"):
+            root = root + "/"
+        href = root + identifier
+        return href, identifier
+
     def _download_cog(self, href: str) -> Path:
-        filename = os.path.basename(href)
+        filename = os.path.basename(href.rstrip("/")) or os.path.basename(href)
         target = self._cache_dir / filename
         if target.exists():
+            self._touch_cache_entry(target)
             return target
 
         LOGGER.info("Downloading DEM tile %s", href)
-        with requests.get(href, stream=True, timeout=30) as response:
-            response.raise_for_status()
-            with open(target, "wb") as handle:
-                for chunk in response.iter_content(chunk_size=1024 * 512):
-                    handle.write(chunk)
+        if href.startswith("http://") or href.startswith("https://"):
+            with requests.get(href, stream=True, timeout=self._cache_cfg.http_timeout_sec) as response:
+                response.raise_for_status()
+                with open(target, "wb") as handle:
+                    for chunk in response.iter_content(chunk_size=1024 * 512):
+                        handle.write(chunk)
+        else:
+            source = Path(href)
+            if not source.exists():
+                raise FileNotFoundError(href)
+            with open(source, "rb") as src, open(target, "wb") as dst:
+                dst.write(src.read())
+        self._touch_cache_entry(target)
+        self._enforce_cache_limit()
         return target
+
+    def _touch_cache_entry(self, path: Path) -> None:
+        stat = path.stat()
+        self._cache_index[str(path)] = {"size": float(stat.st_size), "last_used": time.time()}
+        self._save_cache_index()
+
+    def _enforce_cache_limit(self) -> None:
+        max_bytes = self._cache_cfg.max_bytes
+        entries = list(self._cache_index.items())
+        total = sum(entry[1]["size"] for entry in entries)
+        if total <= max_bytes:
+            return
+        entries.sort(key=lambda item: item[1].get("last_used", 0.0))
+        for path_str, _ in entries:
+            if total <= max_bytes:
+                break
+            path = Path(path_str)
+            LOGGER.info("Evicting DEM tile %s to honor cache limits", path.name)
+            with self._lock:
+                ds = self._dataset_cache.pop(str(path), None)
+                if ds is not None:
+                    ds.close()
+            if path.exists():
+                path.unlink()
+            entry = self._cache_index.pop(path_str, None)
+            if entry:
+                total -= entry["size"]
+        self._save_cache_index()
+
+    def _load_cache_index(self) -> Dict[str, Dict[str, float]]:
+        if self._cache_index_path.exists():
+            try:
+                with open(self._cache_index_path, "r", encoding="utf-8") as handle:
+                    return json.load(handle)
+            except (json.JSONDecodeError, OSError):  # pragma: no cover - corruption guard
+                LOGGER.warning("Failed to parse DEM cache index, rebuilding")
+        return {}
+
+    def _save_cache_index(self) -> None:
+        with open(self._cache_index_path, "w", encoding="utf-8") as handle:
+            json.dump(self._cache_index, handle)
 
     def _dataset(self, tile: DEMTileRecord) -> rasterio.io.DatasetReader:
         with self._lock:
@@ -119,8 +230,9 @@ class DEMManager:
 
         point = Point(lon, lat)
         for tile in self._tile_records:
-            if tile.footprint.contains(point):
+            if tile.footprint.contains(point) or tile.footprint.touches(point):
                 height = self._sample_tile(tile, lat, lon)
+                self._touch_cache_entry(Path(tile.path))
                 meta = {
                     "dem_product": tile.product,
                     "tile_ids": [tile.identifier],

--- a/georeg/geo_projector.py
+++ b/georeg/geo_projector.py
@@ -1,0 +1,138 @@
+"""Geo projection and ray/DEM intersection."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+import logging
+import math
+
+import numpy as np
+import pyproj
+
+from .camera_model import CameraModel
+from .dem_manager import DEMManager
+from .geoid import GeoidModel
+from .models import DetectionResult, Provenance
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class GeoProjector:
+    """Perform ray-terrain intersection using bounded Newton iterations."""
+
+    dem: DEMManager
+    geoid: GeoidModel
+    camera: CameraModel
+    eps_m: float = 0.05
+    max_iters: int = 2
+    dem_variance: float = 1.0
+    _ecef_to_geo: pyproj.Transformer = field(init=False)
+    _geo_to_ecef: pyproj.Transformer = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._ecef_to_geo = pyproj.Transformer.from_crs("EPSG:4978", "EPSG:4979", always_xy=True)
+        self._geo_to_ecef = pyproj.Transformer.from_crs("EPSG:4979", "EPSG:4978", always_xy=True)
+
+    def _pose_to_ecef(self, R_wc: np.ndarray, t_wc: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        if R_wc.shape != (3, 3):
+            raise ValueError("Rotation matrix must be 3x3")
+        if t_wc.shape != (3,):
+            raise ValueError("Translation must be 3-vector")
+        origin = t_wc.astype(float)
+        return origin, R_wc.astype(float)
+
+    def _ecef_to_llh(self, point: np.ndarray) -> tuple[float, float, float]:
+        lon, lat, h = self._ecef_to_geo.transform(point[0], point[1], point[2])
+        return lat, lon, h
+
+    def _llh_to_ecef(self, lat: float, lon: float, h: float) -> np.ndarray:
+        x, y, z = self._geo_to_ecef.transform(lon, lat, h)
+        return np.array([x, y, z])
+
+    def intersect_ray_dem(
+        self,
+        u: float,
+        v: float,
+        zoom: float,
+        R_wc: np.ndarray,
+        t_wc: np.ndarray,
+        lrf: Optional[Dict[str, float]] = None,
+        meta_in: Optional[Dict[str, object]] = None,
+    ) -> DetectionResult:
+        origin, R = self._pose_to_ecef(R_wc, t_wc)
+        K = self.camera.K_for_zoom(zoom)
+        dir_cam = self.camera.dir_cam(u, v, K)
+        d_world = R @ dir_cam
+        d_world = d_world / np.linalg.norm(d_world)
+
+        h0 = self.dem.initial_height()
+        # Convert initial height to ellipsoidal
+        lat0, lon0, h_ellip0 = self._ecef_to_llh(origin)
+        h0_ellip = self.geoid.orthometric_to_ellipsoidal(lat0, lon0, h0)
+        w = (h0_ellip - origin[2]) / d_world[2]
+
+        residual = math.inf
+        used_iters = 0
+        last_height = h0
+        last_lat = lat0
+        last_lon = lon0
+        for it in range(self.max_iters):
+            candidate = origin + w * d_world
+            lat, lon, h_ellip = self._ecef_to_llh(candidate)
+            H = self.geoid.ellipsoidal_to_orthometric(lat, lon, h_ellip)
+            dem_height, dem_meta = self.dem.sample(lat, lon)
+            residual = H - dem_height
+            last_height = dem_height
+            last_lat = lat
+            last_lon = lon
+            used_iters = it + 1
+            if abs(residual) < self.eps_m:
+                break
+            # numeric derivative
+            delta = 0.01
+            candidate_delta = origin + (w + delta) * d_world
+            lat_d, lon_d, h_ellip_d = self._ecef_to_llh(candidate_delta)
+            H_d = self.geoid.ellipsoidal_to_orthometric(lat_d, lon_d, h_ellip_d)
+            deriv = (H_d - H) / delta
+            if abs(deriv) < 1e-6:
+                LOGGER.debug("Derivative too small, breaking early")
+                break
+            w -= residual / deriv
+
+        lrf_used = False
+        fused_height = last_height
+        variance = self.dem_variance
+        if lrf and lrf.get("valid", True):
+            range_m = float(lrf["range_m"])
+            var_lrf = float(lrf.get("variance", 1.0))
+            w_lrf = range_m
+            # Convert range to orthometric height at intersection point
+            candidate_lrf = origin + w_lrf * d_world
+            lat_lrf, lon_lrf, h_lrf = self._ecef_to_llh(candidate_lrf)
+            H_lrf = self.geoid.ellipsoidal_to_orthometric(lat_lrf, lon_lrf, h_lrf)
+            fused_height = (last_height / variance + H_lrf / var_lrf) / (1.0 / variance + 1.0 / var_lrf)
+            lrf_used = True
+
+        provenance = Provenance(
+            dem_product=dem_meta["dem_product"],
+            tile_ids=dem_meta["tile_ids"],
+            geoid=self.geoid.model_name,
+            intrinsics_profile=self.camera.intrinsics_hash(),
+            residual_m=float(abs(residual)),
+            iters=used_iters,
+            lrf_used=lrf_used,
+            confidence=float(math.exp(-abs(residual))),
+            extra=meta_in or {},
+        )
+
+        return DetectionResult(
+            lat=last_lat,
+            lon=last_lon,
+            alt_orthometric=fused_height,
+            residual_m=float(abs(residual)),
+            iters=used_iters,
+            lrf_used=lrf_used,
+            provenance=provenance,
+        )

--- a/georeg/geoid.py
+++ b/georeg/geoid.py
@@ -1,0 +1,58 @@
+"""Geoid helpers for datum consistency."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+try:  # pragma: no cover - optional dependency runtime check
+    from geographiclib.geoids import Geoid  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    Geoid = None  # type: ignore
+
+
+@dataclass(slots=True)
+class GeoidModel:
+    """Wrapper around :mod:`geographiclib` that exposes convenience methods."""
+
+    model: str = "EGM2008"
+    grid_path: Optional[str] = None
+    _geoid: Optional[object] = field(init=False, default=None)
+    _fallback: Optional[float] = field(init=False, default=None)
+
+    def __post_init__(self) -> None:
+        kwargs = {"name": self.model}
+        if self.grid_path:
+            kwargs["path"] = self.grid_path
+        try:
+            if Geoid is None:
+                raise RuntimeError("geographiclib geoid grids not available")
+            self._geoid = Geoid(**kwargs)
+            self._fallback = None
+        except RuntimeError:
+            # geographiclib raises RuntimeError when the grid file is not present.
+            # For unit tests or offline usage we fall back to a zero separation
+            # approximation which is still datum consistent (albeit less accurate).
+            self._geoid = None
+            self._fallback = 0.0
+
+    def ellipsoidal_to_orthometric(self, lat: float, lon: float, h_ellipsoidal: float) -> float:
+        """Convert ellipsoidal height to orthometric height."""
+
+        separation = self._height(lat, lon)
+        return h_ellipsoidal - separation
+
+    def orthometric_to_ellipsoidal(self, lat: float, lon: float, H: float) -> float:
+        separation = self._height(lat, lon)
+        return H + separation
+
+    @property
+    def model_name(self) -> str:
+        if self._geoid is not None:
+            return self._geoid.description
+        return f"{self.model} (fallback)"
+
+    def _height(self, lat: float, lon: float) -> float:
+        if self._geoid is None:
+            return 0.0 if self._fallback is None else self._fallback
+        return self._geoid.Height(lat, lon)

--- a/georeg/models.py
+++ b/georeg/models.py
@@ -1,0 +1,148 @@
+"""Data models for the georegistration pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+
+
+@dataclass(slots=True)
+class Pose:
+    """Camera pose in the world frame.
+
+    Attributes
+    ----------
+    R_wc:
+        Rotation matrix that maps camera coordinates into the world frame.
+    t_wc:
+        Camera origin expressed in the world frame.  The world frame is
+        expected to be Earth centred, Earth fixed (ECEF) or a local ENU frame
+        that is consistent with the DEM georeferencing.
+    timestamp:
+        Optional timestamp in UTC for provenance logging.
+    """
+
+    R_wc: np.ndarray
+    t_wc: np.ndarray
+    timestamp: Optional[datetime] = None
+
+    def __post_init__(self) -> None:
+        if self.R_wc.shape != (3, 3):
+            raise ValueError("R_wc must be a 3x3 rotation matrix")
+        if self.t_wc.shape != (3,):
+            raise ValueError("t_wc must be a 3-vector")
+
+
+@dataclass(slots=True)
+class Intrinsics:
+    """Camera intrinsics for a given zoom level."""
+
+    zoom: float
+    K: np.ndarray
+    distortion: Optional[Sequence[float]] = None
+    image_size: Optional[Tuple[int, int]] = None
+
+    def __post_init__(self) -> None:
+        if self.K.shape != (3, 3):
+            raise ValueError("Intrinsic matrix K must be 3x3")
+
+
+@dataclass(slots=True)
+class Provenance:
+    """Provenance metadata returned with every georegistered detection."""
+
+    dem_product: str
+    tile_ids: Sequence[str]
+    geoid: str
+    intrinsics_profile: str
+    residual_m: float
+    iters: int
+    lrf_used: bool
+    confidence: float
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        base = {
+            "dem_product": self.dem_product,
+            "tile_ids": list(self.tile_ids),
+            "geoid": self.geoid,
+            "intrinsics_profile": self.intrinsics_profile,
+            "residual_m": float(self.residual_m),
+            "iters": int(self.iters),
+            "lrf_used": bool(self.lrf_used),
+            "confidence": float(self.confidence),
+        }
+        base.update(self.extra)
+        return base
+
+
+@dataclass(slots=True)
+class DetectionResult:
+    """Result returned per detection."""
+
+    lat: float
+    lon: float
+    alt_orthometric: float
+    residual_m: float
+    iters: int
+    lrf_used: bool
+    provenance: Provenance
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = {
+            "lat": float(self.lat),
+            "lon": float(self.lon),
+            "alt_orthometric": float(self.alt_orthometric),
+            "residual_m": float(self.residual_m),
+            "iters": int(self.iters),
+            "lrf_used": bool(self.lrf_used),
+        }
+        data.update({"provenance": self.provenance.to_dict()})
+        return data
+
+
+@dataclass(slots=True)
+class LRFMeasurement:
+    """Simple representation of a laser range finder measurement."""
+
+    range_m: float
+    variance: float
+    valid: bool = True
+
+
+@dataclass(slots=True)
+class DEMTileRecord:
+    """Metadata describing a cached DEM tile."""
+
+    product: str
+    identifier: str
+    path: str
+    footprint: Any
+    resolution: float
+    nodata: Optional[float]
+
+
+@dataclass(slots=True)
+class Corridor:
+    """Container storing the flight corridor geometries."""
+
+    polygon_wgs84: Any
+    polygon_projected: Any
+    projected_crs: Any
+
+
+def hash_intrinsics_profile(entries: Iterable[Tuple[str, Any]]) -> str:
+    """Create a deterministic hash string for provenance.
+
+    The helper keeps provenance logic in a single location so that hashing can
+    be improved without touching multiple files.
+    """
+
+    import hashlib
+    import json
+
+    serialised = json.dumps(list(entries), sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(serialised.encode("utf-8")).hexdigest()
+    return digest

--- a/georeg/pipeline.py
+++ b/georeg/pipeline.py
@@ -1,0 +1,84 @@
+"""High level orchestration utilities for the georegistration pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping, Optional, Sequence, Tuple
+
+import numpy as np
+
+from .camera_model import CameraModel
+from .config import Config
+from .dem_manager import DEMManager
+from .geo_projector import GeoProjector
+from .geoid import GeoidModel
+from .models import DetectionResult
+
+
+@dataclass(slots=True)
+class GeoregistrationPipeline:
+    """Convenience wrapper assembling the full pipeline end-to-end."""
+
+    config: Config
+    dem_manager: DEMManager
+    camera: CameraModel
+    geoid: GeoidModel
+    projector: GeoProjector
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Config,
+        waypoints_wgs84: Sequence[Tuple[float, float]],
+    ) -> "GeoregistrationPipeline":
+        """Build a ready-to-use pipeline from a :class:`Config` instance."""
+
+        dem_manager = DEMManager(config.dem)
+        dem_manager.build_corridor(waypoints_wgs84, buffer_m=config.dem.buffer_m)
+        dem_manager.ensure_tiles()
+
+        camera = CameraModel(config.camera.lut_json)
+        geoid = GeoidModel(model=config.geoid.model, grid_path=(str(config.geoid.grid_path) if config.geoid.grid_path else None))
+        projector = GeoProjector(
+            dem=dem_manager,
+            geoid=geoid,
+            camera=camera,
+            eps_m=config.runtime.eps_m,
+            max_iters=config.runtime.max_iters,
+            dem_variance=config.runtime.dem_variance,
+        )
+        return cls(
+            config=config,
+            dem_manager=dem_manager,
+            camera=camera,
+            geoid=geoid,
+            projector=projector,
+        )
+
+    def process_detection(
+        self,
+        u: float,
+        v: float,
+        zoom: float,
+        R_wc: np.ndarray,
+        t_wc: np.ndarray,
+        lrf: Optional[Mapping[str, float]] = None,
+        meta: Optional[MutableMapping[str, object]] = None,
+    ) -> DetectionResult:
+        """Run the complete georegistration flow for one detection."""
+
+        lrf_payload = dict(lrf) if lrf is not None else None
+        extra_meta = dict(meta) if meta is not None else None
+        return self.projector.intersect_ray_dem(
+            u=u,
+            v=v,
+            zoom=zoom,
+            R_wc=R_wc,
+            t_wc=t_wc,
+            lrf=lrf_payload,
+            meta_in=extra_meta,
+        )
+
+    def close(self) -> None:
+        """Release open file handles and cached datasets."""
+
+        self.dem_manager.close()

--- a/georeg/tests/conftest.py
+++ b/georeg/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/georeg/tests/test_corridor.py
+++ b/georeg/tests/test_corridor.py
@@ -1,0 +1,19 @@
+import pytest
+
+shapely = pytest.importorskip("shapely")
+Point = shapely.geometry.Point
+
+from georeg.corridor import CorridorBuilder
+
+
+def test_corridor_contains_waypoints():
+    builder = CorridorBuilder(buffer_m=500)
+    waypoints = [
+        (37.0, -122.0),
+        (37.005, -122.01),
+        (37.01, -122.02),
+    ]
+    corridor = builder.build_corridor(waypoints)
+
+    for lat, lon in waypoints:
+        assert corridor.polygon_wgs84.contains(Point(lon, lat))

--- a/georeg/tests/test_dem_manager.py
+++ b/georeg/tests/test_dem_manager.py
@@ -8,7 +8,7 @@ shapely = pytest.importorskip("shapely")
 from rasterio.transform import from_origin
 box = shapely.geometry.box
 
-from georeg.config import DEMConfig, DEMProviderConfig
+from georeg.config import DEMCacheConfig, DEMConfig, DEMProviderConfig
 from georeg.dem_manager import DEMManager
 
 
@@ -70,12 +70,9 @@ def test_dem_fetch_and_cache(monkeypatch, tmp_path):
     monkeypatch.setattr("georeg.dem_manager.Client", FakeClient)
     monkeypatch.setattr(DEMManager, "_download_cog", lambda self, href: Path(href))
 
-    config = DEMConfig(
-        providers=[DEMProviderConfig(name="test", stac_url="https://example", collection="x")],
-        cache_dir=tmp_path,
-        max_cache_gb=1,
-        buffer_m=1000,
-    )
+    provider = DEMProviderConfig(name="test", stac_url="https://example", collection="x")
+    cache_cfg = DEMCacheConfig(directory=tmp_path, max_bytes=10 * 1024**2, index_file="index.json", http_timeout_sec=5.0)
+    config = DEMConfig(primary=provider, fallbacks=[], cache=cache_cfg, buffer_m=1000)
     dem = DEMManager(config)
     dem.build_corridor([(0.0, 0.0), (0.0, 0.01)])
     dem.ensure_tiles()

--- a/georeg/tests/test_dem_manager.py
+++ b/georeg/tests/test_dem_manager.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+import pytest
+
+np = pytest.importorskip("numpy")
+rasterio = pytest.importorskip("rasterio")
+shapely = pytest.importorskip("shapely")
+from rasterio.transform import from_origin
+box = shapely.geometry.box
+
+from georeg.config import DEMConfig, DEMProviderConfig
+from georeg.dem_manager import DEMManager
+
+
+class FakeAsset:
+    def __init__(self, href: str):
+        self.href = href
+        self.extra_fields = {"gsd": 30, "nodata": None}
+
+
+class FakeItem:
+    def __init__(self, identifier: str, href: str, geometry):
+        self.id = identifier
+        self.assets = {"data": FakeAsset(href)}
+        self.geometry = geometry
+        self.properties = {}
+
+
+class FakeSearch:
+    def __init__(self, items):
+        self._items = items
+
+    def get_items(self):
+        for item in self._items:
+            yield item
+
+
+class FakeClient:
+    def __init__(self, items):
+        self._items = items
+
+    @classmethod
+    def open(cls, url: str):
+        return cls(cls._items)
+
+    def search(self, **_: object):
+        return FakeSearch(self._items)
+
+
+def test_dem_fetch_and_cache(monkeypatch, tmp_path):
+    raster_path = tmp_path / "tile.tif"
+    data = np.array([[100.0, 101.0], [102.0, 103.0]], dtype=np.float32)
+    transform = from_origin(-0.01, 0.01, 0.01, 0.01)
+    with rasterio.open(
+        raster_path,
+        "w",
+        driver="GTiff",
+        height=2,
+        width=2,
+        count=1,
+        dtype="float32",
+        crs="EPSG:4326",
+        transform=transform,
+    ) as dst:
+        dst.write(data, 1)
+
+    geom = box(-0.02, -0.02, 0.02, 0.02)
+    FakeClient._items = [FakeItem("tile-001", str(raster_path), geom.__geo_interface__)]
+
+    monkeypatch.setattr("georeg.dem_manager.Client", FakeClient)
+    monkeypatch.setattr(DEMManager, "_download_cog", lambda self, href: Path(href))
+
+    config = DEMConfig(
+        providers=[DEMProviderConfig(name="test", stac_url="https://example", collection="x")],
+        cache_dir=tmp_path,
+        max_cache_gb=1,
+        buffer_m=1000,
+    )
+    dem = DEMManager(config)
+    dem.build_corridor([(0.0, 0.0), (0.0, 0.01)])
+    dem.ensure_tiles()
+
+    height, meta = dem.sample(0.0, 0.0)
+    assert 100.0 <= height <= 103.0
+    assert meta["dem_product"] == "test"
+    assert meta["tile_ids"] == ["tile-001"]

--- a/georeg/tests/test_geo_projector.py
+++ b/georeg/tests/test_geo_projector.py
@@ -1,0 +1,52 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from georeg.geo_projector import GeoProjector
+from georeg.models import DetectionResult
+
+
+class StubDEM:
+    def initial_height(self) -> float:
+        return 0.0
+
+    def sample(self, lat: float, lon: float):
+        return 0.0, {"dem_product": "stub", "tile_ids": ["stub-tile"]}
+
+
+class StubGeoid:
+    def ellipsoidal_to_orthometric(self, lat: float, lon: float, h: float) -> float:
+        return h
+
+    def orthometric_to_ellipsoidal(self, lat: float, lon: float, H: float) -> float:
+        return H
+
+    @property
+    def model_name(self) -> str:
+        return "stub"
+
+
+class StubCamera:
+    def K_for_zoom(self, zoom: float):
+        return np.eye(3)
+
+    def dir_cam(self, u: float, v: float, K: np.ndarray) -> np.ndarray:
+        return np.array([0.0, 0.0, 1.0])
+
+    def intrinsics_hash(self) -> str:
+        return "stub"
+
+
+def test_newton_converges_flat_terrain(monkeypatch):
+    projector = GeoProjector(dem=StubDEM(), geoid=StubGeoid(), camera=StubCamera(), eps_m=0.01, max_iters=2)
+
+    monkeypatch.setattr(GeoProjector, "_ecef_to_llh", lambda self, point: (point[1], point[0], point[2]))
+    monkeypatch.setattr(GeoProjector, "_pose_to_ecef", lambda self, R, t: (t, R))
+
+    R = np.diag([1.0, 1.0, -1.0])
+    t = np.array([0.0, 0.0, 100.0])
+
+    result = projector.intersect_ray_dem(u=0.0, v=0.0, zoom=1.0, R_wc=R, t_wc=t)
+    assert isinstance(result, DetectionResult)
+    assert abs(result.alt_orthometric) < 1e-6
+    assert result.iters <= 2

--- a/georeg/tests/test_geoid.py
+++ b/georeg/tests/test_geoid.py
@@ -1,0 +1,8 @@
+from georeg.geoid import GeoidModel
+
+
+def test_geoid_fallback_zero():
+    model = GeoidModel(model="FAKE-MODEL")
+    assert model.ellipsoidal_to_orthometric(0.0, 0.0, 10.0) == 10.0
+    assert model.orthometric_to_ellipsoidal(0.0, 0.0, 10.0) == 10.0
+    assert "FAKE-MODEL" in model.model_name

--- a/georeg/tests/test_geoid.py
+++ b/georeg/tests/test_geoid.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytest.importorskip("numpy")
+
 from georeg.geoid import GeoidModel
 
 

--- a/georeg/tests/test_pipeline.py
+++ b/georeg/tests/test_pipeline.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from georeg.config import CameraConfig, Config, DEMCacheConfig, DEMConfig, DEMProviderConfig, GeoidConfig, RuntimeConfig
+from georeg.models import DetectionResult, Provenance
+from georeg.pipeline import GeoregistrationPipeline
+
+
+class StubDEM:
+    def __init__(self, config):
+        self.config = config
+        self.corridor_args = None
+        self.closed = False
+        self.ensure_called = False
+
+    def build_corridor(self, waypoints, buffer_m=None):
+        self.corridor_args = (list(waypoints), buffer_m)
+
+    def ensure_tiles(self):
+        self.ensure_called = True
+
+    def close(self):
+        self.closed = True
+
+
+class StubProjector:
+    def __init__(self, dem, geoid, camera, eps_m, max_iters, dem_variance):
+        self.dem = dem
+        self.geoid = geoid
+        self.camera = camera
+        self.params = (eps_m, max_iters, dem_variance)
+
+    def intersect_ray_dem(self, **_: object) -> DetectionResult:
+        provenance = Provenance(
+            dem_product="stub",
+            tile_ids=["tile"],
+            geoid="stub-geoid",
+            intrinsics_profile="hash",
+            residual_m=0.0,
+            iters=1,
+            lrf_used=False,
+            confidence=1.0,
+        )
+        return DetectionResult(
+            lat=1.0,
+            lon=2.0,
+            alt_orthometric=3.0,
+            residual_m=0.0,
+            iters=1,
+            lrf_used=False,
+            provenance=provenance,
+        )
+
+
+def test_pipeline_wires_dependencies(monkeypatch, tmp_path):
+    lut_path = tmp_path / "calib.json"
+    lut_path.write_text(
+        """
+        {
+          "4.0": {
+            "K": [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+          }
+        }
+        """.strip()
+    )
+
+    monkeypatch.setattr("georeg.pipeline.DEMManager", StubDEM)
+    monkeypatch.setattr("georeg.pipeline.GeoProjector", StubProjector)
+
+    provider = DEMProviderConfig(name="stub", stac_url="https://example.com", collection="x")
+    cache_cfg = DEMCacheConfig(directory=tmp_path / "cache", max_bytes=1024 * 1024)
+    dem_cfg = DEMConfig(primary=provider, fallbacks=[], cache=cache_cfg, buffer_m=1500.0)
+    camera_cfg = CameraConfig(lut_json=lut_path)
+    geoid_cfg = GeoidConfig(model="EGM2008")
+    runtime_cfg = RuntimeConfig(eps_m=0.05, max_iters=2, use_lrf=True, dem_variance=1.5)
+    config = Config(dem=dem_cfg, camera=camera_cfg, geoid=geoid_cfg, runtime=runtime_cfg)
+
+    waypoints = [(0.0, 0.0), (0.0, 0.01)]
+    pipeline = GeoregistrationPipeline.from_config(config, waypoints)
+
+    assert isinstance(pipeline.dem_manager, StubDEM)
+    assert pipeline.dem_manager.corridor_args == (list(waypoints), 1500.0)
+    assert pipeline.dem_manager.ensure_called
+
+    R = np.eye(3)
+    t = np.zeros(3)
+    result = pipeline.process_detection(u=0.0, v=0.0, zoom=4.0, R_wc=R, t_wc=t)
+    assert isinstance(result, DetectionResult)
+
+    pipeline.close()
+    assert pipeline.dem_manager.closed


### PR DESCRIPTION
## Summary
- add the new `georeg` Python package implementing models, camera intrinsics interpolation, corridor building, DEM discovery/sampling, geoid handling, and bounded Newton ray-terrain intersection
- include configuration helpers and provenance utilities to support automatic DEM preparation and metadata capture
- provide pytest-based unit tests for corridor coverage, DEM caching, Newton convergence, and geoid fallback logic while updating the gitignore for Python artifacts

## Testing
- pytest georeg/tests

------
https://chatgpt.com/codex/tasks/task_e_68ef9441e98c83238746b6cd3b8caf9d